### PR TITLE
Add pytest-cov to dev deps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 pytest==9.0.2
 pytest-timeout==2.4.0
+pytest-cov==7.1.0
 httpx==0.28.1


### PR DESCRIPTION
Closes #53

## Summary
Adds `pytest-cov==7.1.0` to `requirements-dev.txt` so the Tests workflow can actually run `pytest --cov=api --cov-report=term-missing` instead of erroring out on unrecognized arguments before any test runs.

## Why 7.1.0
Latest release (verified against PyPI). Requires `pytest>=7`, compatible with the pinned `pytest==9.0.2`.

## Test plan
- CI re-runs on this PR; the Tests workflow should now resolve the `--cov` flags and execute the suite.
- No production code touched.

This is the parsival counterpart to rcanterberryhall/hexcaliper-lanceLLMot#35 (lancellmot used 6.0.0 because it pins pytest 8.3.5; both versions work for their respective pytest pins).