### PR TITLE
Show completed action items in situation cards

### DIFF
--- a/api/situation_manager.py
+++ b/api/situation_manager.py
@@ -616,6 +616,9 @@ def _situation_response(sit: dict) -> dict:
     item_ids = sit.get("item_ids", [])
     with db.lock:
         items_raw = [db.get_item(iid) for iid in item_ids]
+        all_todos = []
+        for iid in item_ids:
+            all_todos.extend(db.get_todos_for_item(iid))
     items = [
         {
             "item_id":   r.get("item_id"),
@@ -626,6 +629,10 @@ def _situation_response(sit: dict) -> dict:
         }
         for r in items_raw if r
     ]
+    done_keys = {
+        (t["item_id"], t["description"])
+        for t in all_todos if t.get("done")
+    }
     from datetime import datetime, timezone
     follow_up_date   = sit.get("follow_up_date")
     follow_up_overdue = False
@@ -646,7 +653,10 @@ def _situation_response(sit: dict) -> dict:
         "priority":        sit.get("priority"),
         "sources":         sit.get("sources", []),
         "project_tag":     sit.get("project_tag"),
-        "open_actions":    sit.get("open_actions", []),
+        "open_actions":    [
+            {**a, "done": (a.get("source_item_id"), a.get("description")) in done_keys}
+            for a in sit.get("open_actions", [])
+        ],
         "references":      sit.get("references", []),
         "key_context":     sit.get("key_context"),
         "last_updated":    sit.get("last_updated"),

--- a/web/page/index.html
+++ b/web/page/index.html
@@ -611,6 +611,11 @@ body { background: var(--bg); color: var(--text); font-family: var(--mono); font
 .status-waiting        { background: rgba(255,176,32,.08);  color: var(--amber); border: 1px solid rgba(255,176,32,.2); }
 .status-needs_decision { background: rgba(212,160,23,.1);   color: var(--gold);  border: 1px solid rgba(212,160,23,.25); }
 .status-informational  { background: rgba(110,80,80,.1);    color: var(--muted); border: 1px solid var(--border); }
+.sit-actions-list { margin-top: 4px; }
+.sit-action-item { font-size: 10px; color: var(--accent); padding: 1px 0; line-height: 1.4; }
+.sit-action-item::before { content: '⚡ '; }
+.sit-action-item.done { text-decoration: line-through; color: var(--muted); }
+.sit-action-item.done::before { content: '✓ '; }
 .stat-situations { grid-column: 1 / -1; }
 .stat-intel      { grid-column: 1 / -1; }
 .attention-cold-banner { font-size:11px; color:var(--muted); background:rgba(110,80,80,.08); border:1px solid var(--border); border-radius:var(--r); padding:6px 12px; margin-bottom:10px; }
@@ -1654,6 +1659,7 @@ tr.attn-low  { opacity:0.65; }
         <dt>Status workflow</dt><dd><strong>new</strong> → <strong>investigating</strong> → <strong>waiting</strong> (with optional follow-up date) → <strong>resolved</strong> or <strong>dismissed</strong>. Use the status dropdown on each situation card.</dd>
         <dt>Follow-up date</dt><dd>Set a date when the situation needs attention next. Situations in "waiting" status past their follow-up date surface at the top of the list with a visual indicator.</dd>
         <dt>Score</dt><dd>Composite urgency — higher means more attention needed now.</dd>
+        <dt>Action items</dt><dd>Each situation card lists your action items inline. Completed items appear with a strikethrough and checkmark so you can see progress at a glance.</dd>
         <dt>Default filter</dt><dd>The list shows <strong>new</strong>, <strong>investigating</strong>, and <strong>waiting</strong> situations by default. Toggle to see resolved/dismissed.</dd>
         <dt>Transition log</dt><dd>Every status change is logged with timestamp and optional note.</dd>
       </dl>
@@ -3024,7 +3030,9 @@ function situationCard(s) {
   const statusLabel = `<span class="sit-detail-status status-${s.status||'informational'}">${(s.status||'informational').replace('_',' ')}</span>`;
   const actions     = (s.open_actions||[]).filter(a => a.owner === 'me' || a.owner === 'Me');
   const actLine     = actions.length
-    ? `<span style="font-size:10px;color:var(--accent)">⚡ ${actions.length} action${actions.length!==1?'s':''} for you</span>`
+    ? `<div class="sit-actions-list">${actions.map(a =>
+        `<div class="sit-action-item${a.done?' done':''}">${esc(a.description)}</div>`
+      ).join('')}</div>`
     : '';
   const evidenceRows = (s.items||[]).map(i =>
     `<div class="sit-evidence-item" onclick="event.stopPropagation();openItemDetail('${esc(i.item_id)}')">


### PR DESCRIPTION
Closes #55

Situation cards now display each of your action items inline with completion status instead of just showing a count. Completed action items (those linked to done todos) appear with strikethrough and a checkmark, while open items keep the existing lightning-bolt style. This makes it easy to see progress at a glance without opening the detail view.

**Changes:**
- `api/situation_manager.py`: `_situation_response` cross-references `open_actions` with the `todos` table to annotate each action with a `done` boolean
- `web/page/index.html`: Replaced action count badge with per-item list; added CSS for `.sit-action-item` and `.sit-action-item.done` (strikethrough + muted color); updated embedded help

**Test results:** 403/403 tests pass, no regressions.

**Visual verification pending — automated agent. Manual browser check required before merge.**