### PR TITLE
fix(ingest): fan out process_ingest_items so merLLM can use both GPUs

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -556,9 +556,11 @@ Parsival runs several concurrent threads against a shared SQLite database and a 
 
 > merLLM is the single source of truth for GPU concurrency. parsival never gates LLM traffic on its own. If we ever need backpressure from merLLM, the right place is merLLM returning 429s (or its tracked queue blocking) — not a parsival-side pre-throttle.
 
+**Ingest fan-out (parsival#75).** `process_ingest_items` used to iterate its input list sequentially, so even with the semaphore removed merLLM's scheduler only ever saw one outstanding parsival job at a time and routed every call to the same GPU slot. A batch is now fanned out over a bounded `ThreadPoolExecutor` (default 4 workers, override via `INGEST_CONCURRENCY`) so multiple items are in flight concurrently and merLLM's round-robin can land them on different GPUs. `run_scan` and `run_reanalyze` remain single-threaded for now — they are not the reported bottleneck and `run_reanalyze` already hands off to merLLM's batch API.
+
 `db.lock` (a `threading.RLock()`) serialises all SQLite write operations. SQLite's WAL mode already allows concurrent reads to proceed while a write is in progress, so reads do not need to acquire this lock. Only operations that call `INSERT`, `UPDATE`, `DELETE`, or `UPSERT` acquire `db.lock`. Callers that need atomicity across multiple write operations — for example, upsert an item then insert a todo — acquire the lock themselves and call the `db.*` helpers within a single `with db.lock:` block. The lock is re-entrant so a thread that already holds it can call any helper without self-deadlocking.
 
-All long-running background jobs (`run_scan`, `run_reanalyze`, `process_ingest_items`) check `scan_state["cancelled"]` before processing each item and exit cleanly after the current item finishes. This means a cancel request is always honoured within one item's worth of latency (typically a few seconds) rather than requiring a process kill.
+All long-running background jobs (`run_scan`, `run_reanalyze`, `process_ingest_items`) check `scan_state["cancelled"]` before starting work on each item and exit cleanly. `run_scan` / `run_reanalyze` stop after the currently-processing item; `process_ingest_items` fans items out into a thread pool, so on cancel any items already dispatched to merLLM run to completion while items still queued in the pool short-circuit immediately. Either way, cancellation is honoured without requiring a process kill.
 
 ---
 

--- a/api/orchestrator.py
+++ b/api/orchestrator.py
@@ -29,9 +29,11 @@ returning 429s (or its tracked queue blocking) — not a parsival-side
 pre-throttle that has to be kept in sync by hand every time the GPU
 topology changes.
 """
+import os
 import threading
 import time
 from collections import deque
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 
 import logging
@@ -74,6 +76,17 @@ _generate_briefing          = None
 # only: on restart we lose the set, but lost items then reappear via the
 # sidecar's normal lookback window, which is the correct behaviour.
 _in_flight_ids: set[str] = set()
+
+# Fan-out for /ingest: number of items analysed concurrently so merLLM's
+# scheduler sees more than one parsival job at a time and can distribute
+# them across GPU slots (squire#75). merLLM still owns GPU concurrency —
+# this cap only governs how many HTTP calls parsival holds open at once.
+def _ingest_concurrency() -> int:
+    try:
+        n = int(os.environ.get("INGEST_CONCURRENCY", "4"))
+    except ValueError:
+        n = 4
+    return max(1, n)
 
 
 def init(scan_state: dict, save_analysis_fn, spawn_situation_fn,
@@ -658,29 +671,29 @@ def process_ingest_items(raw: list[RawItem]) -> None:
     Called as a FastAPI background task.  Respects ``scan_state["cancelled"]``
     and tracks in-flight count via ``scan_state["ingest_pending"]``.
 
+    Items are fanned out over a bounded ``ThreadPoolExecutor`` so merLLM's
+    scheduler sees multiple parsival jobs at once and can dispatch them
+    across GPU slots (squire#75). Concurrency is capped by
+    ``INGEST_CONCURRENCY`` (default 4) — enough to keep both GPUs busy
+    with a little queue headroom, without holding hundreds of HTTP calls
+    open at once. GPU-level concurrency remains owned by merLLM.
+
     :param raw: List of deduplicated ``RawItem`` objects to analyse.
     :type raw: list[RawItem]
     """
     noise_rules = _get_noise_rules()
     with db.lock:
         _scan_state["ingest_pending"] += len(raw)
-    for idx, item in enumerate(raw):
+
+    def _handle_item(item: RawItem) -> None:
+        # Cancel check at task start so items queued in the executor bail
+        # out instead of hitting merLLM after the user asked to stop.
         if _scan_state["cancelled"]:
-            with db.lock:
-                _scan_state["ingest_pending"] = 0
-                # Clear the claim on every still-queued id so a future
-                # ingest call can re-queue them after cancellation.
-                for remaining in raw[idx:]:
-                    _in_flight_ids.discard(remaining.item_id)
-            log.info("ingest cancelled — stopping after current item")
             return
         matched, rule_type = _nf.should_filter(item, noise_rules)
         if matched:
             _save_filtered_item(item, rule_type)
-            with db.lock:
-                _scan_state["ingest_pending"] = max(0, _scan_state["ingest_pending"] - 1)
-                _in_flight_ids.discard(item.item_id)
-            continue
+            return
         try:
             result = analyze(item, priority="short")
             _save_analysis(result)
@@ -688,9 +701,19 @@ def process_ingest_items(raw: list[RawItem]) -> None:
             _spawn_situation_task(result.item_id)
         except Exception as e:
             log.error("ingest %s: %s", item.item_id, e)
-        with db.lock:
-            _scan_state["ingest_pending"] = max(0, _scan_state["ingest_pending"] - 1)
-            _in_flight_ids.discard(item.item_id)
+
+    max_workers = min(_ingest_concurrency(), max(1, len(raw)))
+    with ThreadPoolExecutor(
+        max_workers=max_workers, thread_name_prefix="ingest"
+    ) as ex:
+        futures = {ex.submit(_handle_item, item): item for item in raw}
+        for fut in as_completed(futures):
+            item = futures[fut]
+            with db.lock:
+                _scan_state["ingest_pending"] = max(
+                    0, _scan_state["ingest_pending"] - 1
+                )
+                _in_flight_ids.discard(item.item_id)
 
 
 # ── Auto-scan scheduler ────────────────────────────────────────────────────────

--- a/api/orchestrator.py
+++ b/api/orchestrator.py
@@ -79,7 +79,7 @@ _in_flight_ids: set[str] = set()
 
 # Fan-out for /ingest: number of items analysed concurrently so merLLM's
 # scheduler sees more than one parsival job at a time and can distribute
-# them across GPU slots (squire#75). merLLM still owns GPU concurrency —
+# them across GPU slots (parsival#75). merLLM still owns GPU concurrency —
 # this cap only governs how many HTTP calls parsival holds open at once.
 def _ingest_concurrency() -> int:
     try:
@@ -673,7 +673,7 @@ def process_ingest_items(raw: list[RawItem]) -> None:
 
     Items are fanned out over a bounded ``ThreadPoolExecutor`` so merLLM's
     scheduler sees multiple parsival jobs at once and can dispatch them
-    across GPU slots (squire#75). Concurrency is capped by
+    across GPU slots (parsival#75). Concurrency is capped by
     ``INGEST_CONCURRENCY`` (default 4) — enough to keep both GPUs busy
     with a little queue headroom, without holding hundreds of HTTP calls
     open at once. GPU-level concurrency remains owned by merLLM.

--- a/tests/test_no_llm_throttle.py
+++ b/tests/test_no_llm_throttle.py
@@ -126,6 +126,65 @@ def test_sync_path_allows_concurrent_llm_calls():
             assert not t1.is_alive() and not t2.is_alive()
 
 
+def test_single_ingest_batch_fans_out_over_merllm(monkeypatch):
+    """One ``process_ingest_items`` call must fan its items out concurrently.
+
+    squire#75: parsival was looping items sequentially, so merLLM's
+    scheduler only ever saw one outstanding job and routed every call to
+    the same GPU slot. A batch of 4 items must land at least 2 analyze()
+    calls in flight at once so both GPUs can be utilised.
+    """
+    monkeypatch.setenv("INGEST_CONCURRENCY", "4")
+
+    in_flight = 0
+    in_flight_lock = threading.Lock()
+    concurrent_peak = 0
+    arrivals = threading.Event()
+    arrivals_count = 0
+    arrivals_lock = threading.Lock()
+    release = threading.Event()
+
+    def fake_analyze(item, **_kwargs):
+        nonlocal in_flight, concurrent_peak, arrivals_count
+        with in_flight_lock:
+            in_flight += 1
+            if in_flight > concurrent_peak:
+                concurrent_peak = in_flight
+        with arrivals_lock:
+            arrivals_count += 1
+            if arrivals_count >= 2:
+                arrivals.set()
+        released = release.wait(timeout=5.0)
+        with in_flight_lock:
+            in_flight -= 1
+        assert released, "release event was never signalled — test deadlocked"
+        return _analysis(item.item_id)
+
+    with patch("orchestrator.analyze", side_effect=fake_analyze), \
+         patch.object(orchestrator, "_save_analysis", lambda *a, **k: None), \
+         patch.object(orchestrator, "_spawn_situation_task", lambda *a, **k: None), \
+         patch("orchestrator.graph.index_item", lambda *a, **k: None):
+
+        worker = threading.Thread(
+            target=orchestrator.process_ingest_items,
+            args=([_raw("a"), _raw("b"), _raw("c"), _raw("d")],),
+        )
+        worker.start()
+        try:
+            assert arrivals.wait(timeout=5.0), (
+                "Only one analyze() call was in flight — parsival is "
+                "serialising items inside a single ingest batch. "
+                "squire#75: fan items out so merLLM sees >1 job."
+            )
+            assert concurrent_peak >= 2, (
+                f"concurrent_peak={concurrent_peak}, expected >= 2"
+            )
+        finally:
+            release.set()
+            worker.join(timeout=5.0)
+            assert not worker.is_alive()
+
+
 def test_orchestrator_has_no_concurrency_semaphore():
     """Module-level guard: ``_sem`` and ``get_sem`` must stay deleted.
 

--- a/tests/test_no_llm_throttle.py
+++ b/tests/test_no_llm_throttle.py
@@ -129,7 +129,7 @@ def test_sync_path_allows_concurrent_llm_calls():
 def test_single_ingest_batch_fans_out_over_merllm(monkeypatch):
     """One ``process_ingest_items`` call must fan its items out concurrently.
 
-    squire#75: parsival was looping items sequentially, so merLLM's
+    parsival#75: parsival was looping items sequentially, so merLLM's
     scheduler only ever saw one outstanding job and routed every call to
     the same GPU slot. A batch of 4 items must land at least 2 analyze()
     calls in flight at once so both GPUs can be utilised.
@@ -174,7 +174,7 @@ def test_single_ingest_batch_fans_out_over_merllm(monkeypatch):
             assert arrivals.wait(timeout=5.0), (
                 "Only one analyze() call was in flight — parsival is "
                 "serialising items inside a single ingest batch. "
-                "squire#75: fan items out so merLLM sees >1 job."
+                "parsival#75: fan items out so merLLM sees >1 job."
             )
             assert concurrent_peak >= 2, (
                 f"concurrent_peak={concurrent_peak}, expected >= 2"


### PR DESCRIPTION
Closes #75

## Summary

`process_ingest_items` looped its input list sequentially, so even though `orchestrator._sem` was removed in squire#33 merLLM's scheduler still only ever saw **one** outstanding parsival job at a time and kept routing every call to the same GPU slot. On a 2-GPU stack this meant the second GPU sat idle through the whole ingest run. This change fans the batch out over a bounded `ThreadPoolExecutor` (default 4 workers, override via `INGEST_CONCURRENCY`) so multiple items are in flight concurrently and merLLM's round-robin can distribute them across slots. GPU-level concurrency is still owned entirely by merLLM — parsival just stops pre-serialising the work.

Cancel semantics preserved: items already dispatched to merLLM finish naturally, items still queued inside the executor check `scan_state["cancelled"]` at task start and short-circuit before hitting the wire. All claim/in-flight/ingest_pending accounting still runs at future completion, so no state is leaked on cancel. `run_scan` / `run_reanalyze` are left untouched — they are not the reported bottleneck and `run_reanalyze` already hands off to merLLM's batch API.

## Test results

- 426 tests pass (was 425 + 1 new regression pin `test_single_ingest_batch_fans_out_over_merllm` in `tests/test_no_llm_throttle.py` — asserts >=2 `analyze()` calls are simultaneously in flight for a single ingest batch).
- Full suite: `python3 -m pytest` → `426 passed in 21.82s`.

**Visual verification pending — automated agent. Manual browser check required before merge.**