### PR TITLE
Scope todo dedup across reply chains via conversation_id (#77)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -641,6 +641,15 @@ def _save_analysis(a: Analysis, reanalyze: bool = False) -> None:
 
         if a.has_action and a.category != "fyi":
             for item in a.action_items:
+                # squire#77: reply chains produce distinct item_ids for each
+                # message, so the item-scoped check alone lets the LLM's
+                # re-extracted action slip through as duplicates.  When the
+                # source provides a conversation_id, also check across every
+                # item in that thread using a normalized-description match.
+                if a.conversation_id and db.todo_exists_in_conversation(
+                    a.conversation_id, item.description
+                ):
+                    continue
                 if not db.todo_exists(a.item_id, item.description):
                     # Auto-assign when the LLM identifies the task belongs to
                     # someone other than the user.  Resolve their email from

--- a/api/db.py
+++ b/api/db.py
@@ -808,6 +808,46 @@ def todo_exists(item_id: str, description: str) -> bool:
     return row is not None
 
 
+def _normalize_todo_description(text: str) -> str:
+    """Normalize a todo description for conversation-scoped dedup.
+
+    Lowercases, collapses internal whitespace, strips trailing
+    punctuation (``.!,;:``).  Intended to catch trivial rewrites the
+    LLM emits across replies in the same thread.
+    """
+    if not text:
+        return ""
+    collapsed = " ".join(text.split())
+    return collapsed.lower().rstrip(".!,;: ")
+
+
+def todo_exists_in_conversation(conversation_id: str, description: str) -> bool:
+    """Return True if any todo linked to an item in ``conversation_id``
+    has a description that normalizes to the same string as ``description``.
+
+    Covers the reply-chain dedup case where each message has its own
+    ``item_id`` but the LLM re-extracts the same action on every reply
+    (see squire#77).  Falls back cleanly — an empty or missing
+    ``conversation_id`` returns False so callers can layer this check
+    in front of the existing item-scoped ``todo_exists``.
+    """
+    if not conversation_id:
+        return False
+    target = _normalize_todo_description(description)
+    if not target:
+        return False
+    rows = conn().execute(
+        "SELECT todos.description FROM todos "
+        "JOIN items ON items.item_id = todos.item_id "
+        "WHERE items.conversation_id = ?",
+        (conversation_id,),
+    ).fetchall()
+    for row in rows:
+        if _normalize_todo_description(row["description"]) == target:
+            return True
+    return False
+
+
 def insert_todo(data: dict) -> int:
     """Insert a todo row and return its auto-generated id."""
     c    = conn()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -468,6 +468,52 @@ def test_save_analysis_does_not_duplicate_todos():
     assert len(todos.all()) == 1
 
 
+def _make_thread_analysis(item_id, conversation_id, description):
+    action = ActionItem(description=description, deadline=None, owner="me")
+    a = _make_analysis(item_id, has_action=True, category="task",
+                       action_items=[action])
+    a.conversation_id = conversation_id
+    return a
+
+
+def test_save_analysis_dedups_todos_across_reply_chain():
+    """squire#77: two items in the same conversation_id with the same
+    action description must only produce one todo, even though their
+    item_ids differ."""
+    _save_analysis(_make_thread_analysis("m1", "conv-1", "Order the part"))
+    _save_analysis(_make_thread_analysis("m2", "conv-1", "Order the part"))
+    assert len(todos.all()) == 1
+
+
+def test_save_analysis_dedups_normalized_rewrites_within_conversation():
+    """Case, whitespace, and trailing-punctuation differences must collapse
+    to a single todo when they share a conversation_id."""
+    _save_analysis(_make_thread_analysis(
+        "m1", "conv-2", "Order the part."
+    ))
+    _save_analysis(_make_thread_analysis(
+        "m2", "conv-2", "order  the part"
+    ))
+    assert len(todos.all()) == 1
+
+
+def test_save_analysis_does_not_dedup_across_different_conversations():
+    """Same description in two different conversations must still
+    produce two todos — dedup is conversation-scoped, not global."""
+    _save_analysis(_make_thread_analysis("m1", "conv-A", "Order the part"))
+    _save_analysis(_make_thread_analysis("m2", "conv-B", "Order the part"))
+    assert len(todos.all()) == 2
+
+
+def test_save_analysis_skips_conversation_dedup_when_id_missing():
+    """Items without a conversation_id (e.g. some connectors) must fall
+    back to the existing item-scoped check — two different item_ids with
+    the same description still produce two todos."""
+    _save_analysis(_make_thread_analysis("m1", "", "Order the part"))
+    _save_analysis(_make_thread_analysis("m2", "", "Order the part"))
+    assert len(todos.all()) == 2
+
+
 def test_save_analysis_does_not_duplicate_intel():
     """Calling _save_analysis twice with the same information_item must produce
     exactly one intel row."""


### PR DESCRIPTION
Closes #77

## Summary

Adds conversation-scoped todo dedup so a reply chain no longer spawns a duplicate todo for each message.  Every message in an Outlook thread has its own `item_id`, so the existing check (`db.todo_exists(item_id, description)` in `_save_analysis`) lets the LLM's re-extracted action slip through on each reply — the motivating case is the five near-identical "Receive replacement transformer" rows on conversation `B577E15C…`.

New helper `db.todo_exists_in_conversation(conversation_id, description)` joins `todos` onto `items` and compares normalized descriptions (lowercase, collapsed whitespace, stripped trailing punctuation).  `_save_analysis` consults it first when the source provides a `conversation_id`, then falls back to the existing item-scoped check — items without `conversation_id` (Slack, GitHub, Jira) behave exactly as before.

This is part 1 of 2 per the issue.  Paraphrase-level near-dup detection (embedding similarity within a conversation) is a separate follow-up once this has been observed in practice.

## Test results

Full suite green: `446 passed in 23.37s` (parsival api image).

New coverage in `tests/test_app.py`:
- Same conversation, same description across different item_ids → one todo.
- Same conversation, normalized rewrite (case / whitespace / trailing punctuation) → one todo.
- Different conversations, same description → two todos (dedup is conversation-scoped, not global).
- Empty `conversation_id` falls back to the existing item-scoped check.
- Existing `test_save_analysis_does_not_duplicate_todos` continues to pass unmodified.

**Visual verification pending — automated agent. Manual browser check required before merge.**