### PR TITLE
Top-page merLLM badge: show active/queued separately (#80)

### DIFF
--- a/web/page/index.html
+++ b/web/page/index.html
@@ -5305,9 +5305,15 @@ async function pollMerllm() {
     const anyFaulted = Object.values(gpus).some(g => g.health === 'faulted');
     const health = allHealthy ? 'healthy' : anyFaulted ? 'faulted' : 'degraded';
     dot.className = 'merllm-dot ' + health;
-    const queue = d.queue?.total ?? 0;
-    label.textContent = 'merLLM' + (queue > 0 ? ` (${queue})` : '');
-    dot.title = `Routing: ${d.routing || 'round_robin'}` + (d.warnings?.length ? '\n⚠ ' + d.warnings.join('\n⚠ ') : '');
+    // Show active/queued separately so a deep backlog (say 2/435) is
+    // visually distinct from a quiet system (2/0) — prior build summed
+    // them and hid the queue depth.
+    const active = d.queue?.running ?? 0;
+    const queued = d.queue?.queued  ?? 0;
+    const badge  = (active > 0 || queued > 0) ? ` (${active}/${queued})` : '';
+    label.textContent = 'merLLM' + badge;
+    const tip = `Active ${active} / Queued ${queued} — routing: ${d.routing || 'round_robin'}`;
+    dot.title = tip + (d.warnings?.length ? '\n⚠ ' + d.warnings.join('\n⚠ ') : '');
     dot.style.boxShadow = d.warnings?.length ? '0 0 0 2px rgba(210,153,34,.4)' : '';
   } catch (_) {
     dot.className = 'merllm-dot unknown';


### PR DESCRIPTION
## Summary
- Badge renders `merLLM (active/queued)` instead of `merLLM (total)`.
- Tooltip shows `Active N / Queued N — routing: …`.

## Why
Previously summed `running + queued` under one number, which hid queue depth — a 2/435 backlog looked like "merLLM (437)" and read as "quiet system." Matches the nomenclature now used on the merLLM dashboard and lancellmot top-button.

## Audit note (other half of #80)
Parsival's batch polling at `orchestrator.py:_poll_batch_once` already has merLLM-owned semantics — per-item `GET /api/batch/results/{job_id}` with 404→clear fallback, no client-side wall-clock deadline. The lancellmot#48 timeout-pattern problem does **not** exist here.

Follow-up candidate (out of #80 scope): migrate parsival's N-GETs-per-tick loop to the new `POST /api/batch/status-by-ids` (rcanterberryhall/hexcaliper-merLLM#71) for one request per poll regardless of pending-item count — same shape as the lancellmot refactor.

## Test plan
- [x] Asset served from nginx; `Active` literal present in page source
- [ ] Visual verification once a real reanalyze backlog hits the UI