### PR TITLE
Thread-aware analysis via prior-message todos hint (#79)

### DIFF
--- a/api/agent.py
+++ b/api/agent.py
@@ -63,7 +63,7 @@ User context:
 - Approval indicators: {approval_ctx} — keywords from items previously confirmed as approval events affecting {user_name}
 - FYI indicators: {fyi_ctx} — keywords from items previously confirmed as informational only for {user_name}
 - Noise/irrelevant topics: {noise_ctx} — if content is primarily about these with no direct relevance to {user_name}, set category="noise", priority="low", has_action=false
-{sender_hint}{replied_hint}{manual_tag_hint}{graph_hint}{embedding_hint}{recipient_scope_hint}
+{sender_hint}{replied_hint}{manual_tag_hint}{graph_hint}{embedding_hint}{recipient_scope_hint}{thread_todos_hint}
 Analyze this item and extract structured information.
 
 Source: {source}
@@ -880,7 +880,33 @@ def _validated_project_tags(tags) -> list[str]:
     return [t for t in tags if isinstance(t, str) and t in valid]
 
 
-def build_prompt(item: RawItem) -> str:
+def _render_thread_todos_hint(thread_todos: list[dict] | None) -> str:
+    """Render the prior-message todos prompt block for parsival#79.
+
+    Empty or None → empty string (no hint), preserving prompt shape for
+    first-in-thread messages and non-email sources.
+    """
+    if not thread_todos:
+        return ""
+    lines = []
+    for t in thread_todos:
+        desc = (t.get("description") or "").strip()
+        if not desc:
+            continue
+        owner = (t.get("owner") or "").strip() or "unassigned"
+        deadline = t.get("deadline") or "no deadline"
+        lines.append(f"  - {desc} (owner: {owner}, due: {deadline})")
+    if not lines:
+        return ""
+    body = "\n".join(lines)
+    return (
+        "\n- Already tracked in this email thread — do NOT re-emit these as "
+        "new action items, even with rewording; still emit any genuinely new "
+        "tasks introduced by this message.\n" + body
+    )
+
+
+def build_prompt(item: RawItem, *, thread_todos: list[dict] | None = None) -> str:
     """
     Build the LLM analysis prompt for an item without submitting it.
 
@@ -890,6 +916,9 @@ def build_prompt(item: RawItem) -> str:
 
     :param item: The raw item to build a prompt for.
     :type item: RawItem
+    :param thread_todos: Open todos already saved for strictly-earlier items
+        in the same ``conversation_id``, rendered as a "do not re-emit" hint
+        to suppress paraphrased duplicates across reply chains (parsival#79).
     :return: Fully formatted prompt string.
     :rtype: str
     """
@@ -974,6 +1003,7 @@ def build_prompt(item: RawItem) -> str:
     recipient_scope_hint = _recipient_scope_hint(
         scope_info, config.USER_NAME or "the user"
     )
+    thread_todos_hint = _render_thread_todos_hint(thread_todos)
 
     return PROMPT.format(
         source       = item.source,
@@ -999,6 +1029,7 @@ def build_prompt(item: RawItem) -> str:
         graph_hint      = graph_hint,
         embedding_hint  = embedding_hint,
         recipient_scope_hint = recipient_scope_hint,
+        thread_todos_hint = thread_todos_hint,
     )
 
 
@@ -1122,7 +1153,12 @@ def build_analysis_from_llm_json(
     )
 
 
-def analyze(item: RawItem, *, priority: str = "short") -> Analysis:
+def analyze(
+    item: RawItem,
+    *,
+    priority: str = "short",
+    thread_todos: list[dict] | None = None,
+) -> Analysis:
     """
     Send a single item to Ollama and parse the structured JSON response.
 
@@ -1236,6 +1272,7 @@ def analyze(item: RawItem, *, priority: str = "short") -> Analysis:
 
     scope_info          = compute_recipient_scope(config.USER_EMAIL or "", to_field, cc_field)
     recipient_scope_hint = _recipient_scope_hint(scope_info, _user_name)
+    thread_todos_hint    = _render_thread_todos_hint(thread_todos)
 
     text = llm.generate(
         PROMPT.format(
@@ -1262,6 +1299,7 @@ def analyze(item: RawItem, *, priority: str = "short") -> Analysis:
             graph_hint      = graph_hint,
             embedding_hint  = embedding_hint,
             recipient_scope_hint = recipient_scope_hint,
+            thread_todos_hint = thread_todos_hint,
         ),
         format="json", temperature=0.1, num_predict=768, timeout=90,
         priority=priority,

--- a/api/db.py
+++ b/api/db.py
@@ -836,6 +836,44 @@ def todo_exists_in_conversation(conversation_id: str, description: str) -> bool:
     return any(_norm_desc(r[0]) == target for r in rows)
 
 
+def get_open_todos_for_conversation(
+    conversation_id: str | None,
+    before_timestamp: str | None = None,
+    limit: int = 15,
+) -> list[dict]:
+    """Return open todos saved for earlier items in this conversation.
+
+    Feeds the LLM a "do not re-emit these" hint when analyzing the next
+    message in a thread (parsival#79). Paraphrase-level dedup the exact /
+    normalized check in todo_exists_in_conversation cannot catch.
+
+    Scoped by ``items.conversation_id``; filtered to ``todos.done = 0``.
+    When ``before_timestamp`` is set, only todos from items with a strictly
+    earlier ``items.timestamp`` are returned — required on reanalyze so a
+    message does not self-suppress its own todos. Most recent ``limit``
+    items win (prompt-bloat guard on very long threads).
+    """
+    if not conversation_id:
+        return []
+    params: list = [conversation_id]
+    where_extra = ""
+    if before_timestamp:
+        where_extra = " AND i.timestamp < ?"
+        params.append(before_timestamp)
+    params.append(int(limit))
+    rows = conn().execute(
+        "SELECT t.description, t.owner, t.deadline "
+        "FROM todos t JOIN items i ON t.item_id = i.item_id "
+        "WHERE i.conversation_id = ? AND t.done = 0" + where_extra + " "
+        "ORDER BY i.timestamp DESC LIMIT ?",
+        params,
+    ).fetchall()
+    return [
+        {"description": r[0], "owner": r[1], "deadline": r[2]}
+        for r in rows
+    ]
+
+
 def insert_todo(data: dict) -> int:
     """Insert a todo row and return its auto-generated id."""
     c    = conn()

--- a/api/orchestrator.py
+++ b/api/orchestrator.py
@@ -32,7 +32,7 @@ topology changes.
 import os
 import threading
 import time
-from collections import deque
+from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 
@@ -568,16 +568,27 @@ def run_reanalyze() -> None:
                 author    = rec.get("author", ""),
                 timestamp = rec.get("timestamp", _now_iso()),
                 metadata  = {
-                    "to":          rec.get("to_field", ""),
-                    "cc":          rec.get("cc_field", ""),
-                    "is_replied":  rec.get("is_replied", False),
-                    "replied_at":  rec.get("replied_at"),
-                    "project_tag": rec.get("project_tag"),
-                    "hierarchy":   rec.get("hierarchy"),
+                    "to":              rec.get("to_field", ""),
+                    "cc":              rec.get("cc_field", ""),
+                    "is_replied":      rec.get("is_replied", False),
+                    "replied_at":      rec.get("replied_at"),
+                    "project_tag":     rec.get("project_tag"),
+                    "hierarchy":       rec.get("hierarchy"),
+                    "conversation_id": rec.get("conversation_id"),
                 },
             )
             try:
-                prompt = build_prompt(item)
+                # parsival#79: thread_todos hint scoped to strictly-earlier
+                # items so this item does not self-suppress using its own
+                # prior-analysis todos.
+                conv_id = rec.get("conversation_id") or ""
+                thread_todos: list[dict] = []
+                if conv_id:
+                    with db.lock:
+                        thread_todos = db.get_open_todos_for_conversation(
+                            conv_id, before_timestamp=item.timestamp
+                        )
+                prompt = build_prompt(item, thread_todos=thread_todos)
                 job_id = _submit_batch_job(prompt)
                 if job_id:
                     with db.lock:
@@ -685,35 +696,77 @@ def process_ingest_items(raw: list[RawItem]) -> None:
     with db.lock:
         _scan_state["ingest_pending"] += len(raw)
 
+    # Group items by conversation_id so a reply chain analyzes oldest-first
+    # sequentially (parsival#79) — each reply then sees prior-message todos
+    # as a "do not re-emit" hint. Items without a conversation_id are
+    # treated as their own singleton group so different sources / standalone
+    # messages keep running in parallel, matching the prior behavior.
+    grouped: dict[str, list[RawItem]] = defaultdict(list)
+    standalones: list[list[RawItem]] = []
+    for item in raw:
+        conv_id = (item.metadata or {}).get("conversation_id") or ""
+        if conv_id:
+            grouped[conv_id].append(item)
+        else:
+            standalones.append([item])
+    for items in grouped.values():
+        items.sort(key=lambda it: it.timestamp)
+    groups: list[list[RawItem]] = list(grouped.values()) + standalones
+
+    def _mark_done(item: RawItem) -> None:
+        with db.lock:
+            _scan_state["ingest_pending"] = max(
+                0, _scan_state["ingest_pending"] - 1
+            )
+            _in_flight_ids.discard(item.item_id)
+
     def _handle_item(item: RawItem) -> None:
         # Cancel check at task start so items queued in the executor bail
         # out instead of hitting merLLM after the user asked to stop.
         if _scan_state["cancelled"]:
+            _mark_done(item)
             return
         matched, rule_type = _nf.should_filter(item, noise_rules)
         if matched:
             _save_filtered_item(item, rule_type)
+            _mark_done(item)
             return
         try:
-            result = analyze(item, priority="short")
+            conv_id = (item.metadata or {}).get("conversation_id") or ""
+            thread_todos: list[dict] = []
+            if conv_id:
+                with db.lock:
+                    thread_todos = db.get_open_todos_for_conversation(
+                        conv_id, before_timestamp=item.timestamp
+                    )
+            result = analyze(
+                item, priority="short", thread_todos=thread_todos
+            )
             _save_analysis(result)
             graph.index_item(result)
             _spawn_situation_task(result.item_id)
         except Exception as e:
             log.error("ingest %s: %s", item.item_id, e)
+        finally:
+            _mark_done(item)
 
-    max_workers = min(_ingest_concurrency(), max(1, len(raw)))
+    def _handle_group(items: list[RawItem]) -> None:
+        # Sequential within a conversation so get_open_todos_for_conversation
+        # sees each preceding item's persisted todos on the next iteration.
+        for item in items:
+            _handle_item(item)
+
+    if not groups:
+        return
+    max_workers = min(_ingest_concurrency(), max(1, len(groups)))
     with ThreadPoolExecutor(
         max_workers=max_workers, thread_name_prefix="ingest"
     ) as ex:
-        futures = {ex.submit(_handle_item, item): item for item in raw}
+        futures = [ex.submit(_handle_group, items) for items in groups]
         for fut in as_completed(futures):
-            item = futures[fut]
-            with db.lock:
-                _scan_state["ingest_pending"] = max(
-                    0, _scan_state["ingest_pending"] - 1
-                )
-                _in_flight_ids.discard(item.item_id)
+            # Exceptions are already caught per-item inside _handle_item;
+            # this loop exists so the context manager waits on every task.
+            pass
 
 
 # ── Auto-scan scheduler ────────────────────────────────────────────────────────

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -65,6 +65,51 @@ def test_analyze_jira_fallback_creates_action_item():
     assert result.action_items[0].deadline == "2024-04-01"
 
 
+# ── build_prompt thread_todos hint (parsival#79) ───────────────────────────────
+
+def test_build_prompt_omits_thread_todos_hint_when_empty():
+    prompt_empty = agent.build_prompt(_raw(), thread_todos=[])
+    prompt_none  = agent.build_prompt(_raw(), thread_todos=None)
+    prompt_default = agent.build_prompt(_raw())
+
+    for p in (prompt_empty, prompt_none, prompt_default):
+        assert "Already tracked in this email thread" not in p
+
+
+def test_build_prompt_includes_thread_todos_hint_when_present():
+    todos_list = [
+        {"description": "Sign the RV9 auth letter", "owner": "me", "deadline": "2026-04-20"},
+        {"description": "Receive replacement transformer", "owner": "me", "deadline": None},
+    ]
+    prompt = agent.build_prompt(_raw(), thread_todos=todos_list)
+
+    assert "Already tracked in this email thread" in prompt
+    assert "do NOT re-emit" in prompt
+    assert "still emit any genuinely new tasks" in prompt
+    assert "Sign the RV9 auth letter" in prompt
+    assert "Receive replacement transformer" in prompt
+    assert "2026-04-20" in prompt
+
+
+def test_analyze_passes_thread_todos_hint_to_llm():
+    """Sync path (analyze) must render the thread_todos hint into the prompt,
+    not just build_prompt (which is the batch path)."""
+    captured = {}
+
+    def fake_generate(prompt, **kwargs):
+        captured["prompt"] = prompt
+        return "{}"
+
+    todos_list = [{"description": "Book the training room",
+                   "owner": "me", "deadline": None}]
+
+    with patch("agent.llm.generate", side_effect=fake_generate):
+        agent.analyze(_raw(), thread_todos=todos_list)
+
+    assert "Already tracked in this email thread" in captured["prompt"]
+    assert "Book the training room" in captured["prompt"]
+
+
 def test_analyze_skips_action_items_without_description():
     payload = {
         "has_action": True,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -496,6 +496,95 @@ def test_save_analysis_allows_same_description_in_different_conversations():
     assert len(todos.all()) == 2
 
 
+# ── get_open_todos_for_conversation (parsival#79) ─────────────────────────────
+
+def _insert_item_row(item_id: str, conversation_id: str, timestamp: str):
+    import db as _db
+    _db.conn().execute(
+        "INSERT INTO items (item_id, conversation_id, timestamp) VALUES (?, ?, ?)",
+        (item_id, conversation_id, timestamp),
+    )
+
+
+def _insert_todo_for(item_id: str, description: str, *, done: bool = False,
+                     owner: str = "me", deadline: str | None = None):
+    todos.insert({
+        "item_id": item_id, "source": "outlook", "title": "T", "url": "",
+        "description": description, "deadline": deadline, "owner": owner,
+        "priority": "medium", "done": done,
+        "created_at": "2026-03-17T10:00:00+00:00",
+    })
+
+
+def test_get_open_todos_for_conversation_returns_only_matching_thread():
+    import db as _db
+    _insert_item_row("a1", "conv-A", "2026-04-01T10:00:00+00:00")
+    _insert_item_row("b1", "conv-B", "2026-04-01T10:00:00+00:00")
+    _insert_todo_for("a1", "Ship the part")
+    _insert_todo_for("b1", "Review quote")
+
+    out = _db.get_open_todos_for_conversation("conv-A")
+
+    descs = [t["description"] for t in out]
+    assert descs == ["Ship the part"]
+
+
+def test_get_open_todos_for_conversation_excludes_done_todos():
+    import db as _db
+    _insert_item_row("x1", "conv-X", "2026-04-01T10:00:00+00:00")
+    _insert_todo_for("x1", "Open task", done=False)
+    _insert_todo_for("x1", "Finished task", done=True)
+
+    out = _db.get_open_todos_for_conversation("conv-X")
+
+    descs = [t["description"] for t in out]
+    assert descs == ["Open task"]
+
+
+def test_get_open_todos_for_conversation_respects_before_timestamp():
+    """Only todos from items with a strictly earlier timestamp are returned —
+    prevents a message from self-suppressing its own todos on reanalyze."""
+    import db as _db
+    _insert_item_row("m1", "conv-T", "2026-04-01T09:00:00+00:00")
+    _insert_item_row("m2", "conv-T", "2026-04-01T10:00:00+00:00")
+    _insert_item_row("m3", "conv-T", "2026-04-01T11:00:00+00:00")
+    _insert_todo_for("m1", "Task from message 1")
+    _insert_todo_for("m2", "Task from message 2")
+    _insert_todo_for("m3", "Task from message 3")
+
+    out = _db.get_open_todos_for_conversation(
+        "conv-T", before_timestamp="2026-04-01T10:30:00+00:00"
+    )
+
+    descs = sorted(t["description"] for t in out)
+    assert descs == ["Task from message 1", "Task from message 2"]
+
+
+def test_get_open_todos_for_conversation_empty_id_returns_empty():
+    import db as _db
+    assert _db.get_open_todos_for_conversation("") == []
+    assert _db.get_open_todos_for_conversation(None) == []
+
+
+def test_get_open_todos_for_conversation_caps_at_default_limit():
+    """Long threads (50+ messages × one todo each) must not blow the prompt —
+    helper caps at 15 most recent by item timestamp."""
+    import db as _db
+    for i in range(25):
+        ts = f"2026-04-01T{i:02d}:00:00+00:00"
+        _insert_item_row(f"i{i}", "conv-long", ts)
+        _insert_todo_for(f"i{i}", f"Task {i}")
+
+    out = _db.get_open_todos_for_conversation("conv-long")
+
+    assert len(out) == 15
+    descs = {t["description"] for t in out}
+    # Most recent 15 messages are i10..i24 — i0..i9 should drop off.
+    assert "Task 24" in descs
+    assert "Task 10" in descs
+    assert "Task 9" not in descs
+
+
 def test_save_analysis_does_not_duplicate_intel():
     """Calling _save_analysis twice with the same information_item must produce
     exactly one intel row."""

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -167,26 +167,28 @@ def test_run_scan_sets_running_false_after_completion():
 
 def _insert_minimal(item_id, source="jira", priority=None, category=None,
                     is_passdown=False,
-                    timestamp="2026-03-17T10:00:00+00:00"):
+                    timestamp="2026-03-17T10:00:00+00:00",
+                    conversation_id=None):
     """Insert a bare-minimum analysis record for reanalysis tests."""
     analyses.insert({
-        "item_id":     item_id,
-        "source":      source,
-        "title":       f"Item {item_id}",
-        "author":      "alice",
-        "timestamp":   timestamp,
-        "url":         "",
-        "body_preview": f"body of {item_id}",
-        "priority":    priority,
-        "category":    category,
-        "has_action":  False,
-        "is_passdown": is_passdown,
-        "project_tag": None,
-        "hierarchy":   "general",
-        "to_field":    "",
-        "cc_field":    "",
-        "is_replied":  False,
-        "replied_at":  None,
+        "item_id":         item_id,
+        "source":          source,
+        "title":           f"Item {item_id}",
+        "author":          "alice",
+        "timestamp":       timestamp,
+        "url":             "",
+        "body_preview":    f"body of {item_id}",
+        "priority":        priority,
+        "category":        category,
+        "has_action":      False,
+        "is_passdown":     is_passdown,
+        "project_tag":     None,
+        "hierarchy":       "general",
+        "to_field":        "",
+        "cc_field":        "",
+        "is_replied":      False,
+        "replied_at":      None,
+        "conversation_id": conversation_id,
     })
 
 
@@ -490,7 +492,7 @@ def test_run_reanalyze_sorts_passdowns_first():
 
     fake_ids = iter(["p1", "n2", "n1"])
 
-    def fake_build_prompt(item):
+    def fake_build_prompt(item, **_kwargs):
         # We rely on build_prompt being called in the same iteration order as
         # the submit loop, so recording the item here gives us submit order.
         submit_order.append(item.item_id)
@@ -581,6 +583,168 @@ def test_process_ingest_items_releases_remaining_claims_on_cancel():
         assert orchestrator._in_flight_ids == set()
     finally:
         scan_state["cancelled"] = False
+
+
+# ── Thread-aware analysis (parsival#79) ───────────────────────────────────────
+
+def _raw_conv(item_id, conversation_id, timestamp,
+              body="body text", source="outlook"):
+    return RawItem(
+        source=source, item_id=item_id, title=f"Item {item_id}",
+        body=body, url="", author="alice@example.com", timestamp=timestamp,
+        metadata={"conversation_id": conversation_id},
+    )
+
+
+def _analysis_with_action(item_id, conversation_id, description,
+                          timestamp="2026-04-01T10:00:00+00:00"):
+    a = Analysis(
+        item_id=item_id, source="outlook", title=f"Item {item_id}",
+        author="alice", timestamp=timestamp, url="",
+        has_action=True, priority="medium", category="task",
+        action_items=[ActionItem(description=description, deadline=None, owner="me")],
+        summary="S", urgency_reason=None,
+    )
+    a.conversation_id = conversation_id
+    return a
+
+
+def test_process_ingest_items_sorts_and_passes_thread_todos_within_conversation():
+    """Within a conversation_id, items are processed oldest-first and each
+    analyze() call receives thread_todos built from earlier messages'
+    persisted todos (parsival#79)."""
+    orchestrator.claim_ingest_items(["m1", "m2", "m3"])
+
+    calls = []
+
+    def fake_analyze(item, **kwargs):
+        calls.append({
+            "item_id": item.item_id,
+            "thread_todos": list(kwargs.get("thread_todos") or []),
+        })
+        return _analysis_with_action(
+            item.item_id, "conv-A",
+            f"Task from {item.item_id}", timestamp=item.timestamp,
+        )
+
+    # Input order is intentionally shuffled — orchestrator must sort.
+    items = [
+        _raw_conv("m3", "conv-A", "2026-04-01T12:00:00+00:00"),
+        _raw_conv("m1", "conv-A", "2026-04-01T10:00:00+00:00"),
+        _raw_conv("m2", "conv-A", "2026-04-01T11:00:00+00:00"),
+    ]
+
+    with patch("orchestrator.analyze", side_effect=fake_analyze), \
+         patch("orchestrator.graph.index_item"), \
+         patch("orchestrator._spawn_situation_task"):
+        orchestrator.process_ingest_items(items)
+
+    assert [c["item_id"] for c in calls] == ["m1", "m2", "m3"]
+    assert calls[0]["thread_todos"] == []
+    call2_descs = {t["description"] for t in calls[1]["thread_todos"]}
+    assert "Task from m1" in call2_descs
+    call3_descs = {t["description"] for t in calls[2]["thread_todos"]}
+    assert {"Task from m1", "Task from m2"}.issubset(call3_descs)
+
+
+def test_process_ingest_items_isolates_thread_todos_between_conversations():
+    """Conversation A's todos must not leak into conversation B's prompt."""
+    orchestrator.claim_ingest_items(["a1", "b1"])
+
+    calls = []
+
+    def fake_analyze(item, **kwargs):
+        calls.append({
+            "item_id": item.item_id,
+            "thread_todos": list(kwargs.get("thread_todos") or []),
+        })
+        conv = item.metadata.get("conversation_id", "")
+        return _analysis_with_action(
+            item.item_id, conv, f"Task from {item.item_id}",
+            timestamp=item.timestamp,
+        )
+
+    with patch("orchestrator.analyze", side_effect=fake_analyze), \
+         patch("orchestrator.graph.index_item"), \
+         patch("orchestrator._spawn_situation_task"):
+        orchestrator.process_ingest_items([
+            _raw_conv("a1", "conv-A", "2026-04-01T10:00:00+00:00"),
+            _raw_conv("b1", "conv-B", "2026-04-01T10:00:00+00:00"),
+        ])
+
+    for c in calls:
+        assert c["thread_todos"] == [], (
+            f"{c['item_id']} saw thread_todos from another conversation"
+        )
+
+
+def test_run_reanalyze_fetches_thread_todos_for_conversation_items():
+    """Bulk reanalyze must rehydrate prior-message thread_todos for items
+    that belong to a conversation, scoped to before the item's timestamp
+    so an item does not self-suppress on its own todos (parsival#79)."""
+    _insert_minimal(
+        "msg-1", source="outlook",
+        timestamp="2026-04-01T09:00:00+00:00",
+        conversation_id="conv-X",
+    )
+    _insert_minimal(
+        "msg-2", source="outlook",
+        timestamp="2026-04-01T11:00:00+00:00",
+        conversation_id="conv-X",
+    )
+    todos.insert({
+        "item_id": "msg-1", "source": "outlook", "title": "T", "url": "",
+        "description": "Review spec", "deadline": None, "owner": "me",
+        "priority": "medium", "done": False,
+        "created_at": "2026-04-01T09:05:00+00:00",
+    })
+
+    captured = []
+
+    def fake_build_prompt(item, **kwargs):
+        captured.append({
+            "item_id": item.item_id,
+            "thread_todos": list(kwargs.get("thread_todos") or []),
+        })
+        return f"prompt for {item.item_id}"
+
+    with patch("orchestrator._merllm_batch_available", return_value=True), \
+         patch("orchestrator._submit_batch_job", return_value="job-x"), \
+         patch("orchestrator.build_prompt", side_effect=fake_build_prompt), \
+         patch("orchestrator._ensure_batch_poll_thread"), \
+         patch("orchestrator._generate_briefing_bg"):
+        _run_reanalyze()
+
+    by_id = {c["item_id"]: c for c in captured}
+    assert by_id["msg-1"]["thread_todos"] == []
+    descs_msg2 = [t["description"] for t in by_id["msg-2"]["thread_todos"]]
+    assert "Review spec" in descs_msg2
+
+
+def test_process_ingest_items_empty_thread_todos_for_standalone_items():
+    """Items without a conversation_id (Slack DMs, GitHub, Jira, etc.) must
+    always receive empty thread_todos — they have no thread to look up."""
+    orchestrator.claim_ingest_items(["s1"])
+
+    captured = {}
+
+    def fake_analyze(item, **kwargs):
+        captured["thread_todos"] = kwargs.get("thread_todos")
+        return _analysis("s1")
+
+    slack_item = RawItem(
+        source="slack", item_id="s1", title="DM",
+        body="hi", url="", author="alice",
+        timestamp="2026-04-01T10:00:00+00:00", metadata={},
+    )
+
+    with patch("orchestrator.analyze", side_effect=fake_analyze), \
+         patch("orchestrator._save_analysis"), \
+         patch("orchestrator.graph.index_item"), \
+         patch("orchestrator._spawn_situation_task"):
+        orchestrator.process_ingest_items([slack_item])
+
+    assert captured["thread_todos"] == []
 
 
 def test_run_reanalyze_aborts_when_merllm_unavailable():


### PR DESCRIPTION
Closes #79

## Summary

Follow-up to #77. That fix killed 4 of 5 duplicate todos in the transformer thread; the survivor was a paraphrase (\"Sign the RV9 auth letter\" vs \"Provide signature for electrical modification verification on the RV9 authorization letter\") that string/normalized dedup can't catch. This PR asks the LLM itself to suppress paraphrases: before analyzing message K in a thread, fetch the open todos already saved for messages 1..K-1 (same conversation_id) and inject them into the prompt as \"already tracked — do not re-emit, even with rewording.\"

## Changes

- **db.py** — ``get_open_todos_for_conversation(conversation_id, before_timestamp, limit=15)`` joins todos onto items, filters ``done=0``, optionally caps by ``items.timestamp``, and returns at most 15 most-recent rows (prompt-bloat guard for long threads).
- **agent.py** — ``build_prompt`` / ``analyze`` accept ``thread_todos=None`` kwarg. Shared ``_render_thread_todos_hint`` renders a new block into the ``PROMPT`` template alongside the existing sender/replied/manual/graph/embedding hints. Empty list → no hint, preserving prompt shape for first-in-thread messages and non-conversation sources.
- **orchestrator.py — process_ingest_items** — groups raw items by ``conversation_id``, sorts each group by timestamp, and processes sequentially within a group (parallel across groups) so each message's analysis sees prior messages' persisted todos. Standalone items (no conversation_id) are their own singleton groups — same throughput as before. Per-item bookkeeping (``ingest_pending`` decrement, ``_in_flight_ids`` discard) moves inside ``_handle_item``'s ``finally`` so noise-filter / cancel / exception paths release cleanly.
- **orchestrator.py — run_reanalyze** — fetches ``thread_todos`` with ``before_timestamp=item.timestamp`` so an item doesn't self-suppress on its own prior-analysis todos, and threads ``conversation_id`` through the RawItem it builds for ``build_prompt``.

## Test results

Full suite: **456 passed** (up from 444, +12 new).

New coverage:
- **db helper**: thread scoping, ``done=0`` filter, ``before_timestamp`` filter, empty-id return, 15-most-recent cap.
- **build_prompt / analyze**: hint omitted when empty/None/default, rendered when present, reaches the sync path's ``llm.generate`` call.
- **process_ingest_items**: within-thread sequential ordering with cumulative ``thread_todos``, cross-thread isolation, standalone items receive empty ``thread_todos``.
- **run_reanalyze**: ``before_timestamp`` filter keeps an item's own todos out while surfacing earlier siblings'.

Existing ``test_run_reanalyze_sorts_passdowns_first``'s local ``fake_build_prompt`` updated to accept ``**kwargs`` so it tolerates the new ``thread_todos`` arg.

## Relation to #77

- #77's ``todo_exists_in_conversation`` stays as the exact/normalized safety net for sources without conversation_id and for the LLM ignoring the hint.
- The embedding-based near-dup follow-up mentioned in #77 is no longer needed if this lands cleanly — revisit only if production shows the hint isn't enough.

**Visual verification pending — rebuild the api image (\`compose up -d --build parsival-api\`) and spot-check the transformer thread before merging.**