### PR TITLE
Add favicon link to parsival dashboard

### DIFF
--- a/web/page/index.html
+++ b/web/page/index.html
@@ -4,6 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Hexcaliper — Parsival</title>
+<link rel="icon" type="image/svg+xml" href="/page/parsival-grail.svg">
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&family=Syne:wght@600;700;800&display=swap" rel="stylesheet">
 <style>
 :root {


### PR DESCRIPTION
Closes #86

## Summary

The parsival dashboard had no `<link rel="icon">` tag in `web/page/index.html`, so browsers rendered a blank favicon in the tab. Adds a single line that points the browser icon at the existing `parsival-grail.svg` brand mark, which is already served from `/page/parsival-grail.svg` by nginx and is reused as the header background and nav brand `<img>`.

No new asset was introduced — the fix reuses the established brand SVG so the favicon stays in sync with any future brand change.

## Test results

- `cd api && python -m pytest` → 460 passed, 0 failed.
- HTML re-parsed with `html.parser` to confirm the new `<link>` has `rel=icon`, `type=image/svg+xml`, `href=/page/parsival-grail.svg`.
- `web/page/parsival-grail.svg` confirmed present on disk.

**Visual verification pending — automated agent. Manual browser check required before merge.**