### PR TITLE
web: auto-focus title input on + New card (#88)

### DIFF
--- a/web/page/index.html
+++ b/web/page/index.html
@@ -2545,7 +2545,8 @@ async function createManualCard() {
     // Best-effort cache refresh; a failed reload must not mask the successful POST.
     await Promise.allSettled([loadTodos(), loadItems()]);
     const newItemId = resp.item_id || `manual_${resp.doc_id}`;
-    openTodoDetail(newItemId);
+    await openTodoDetail(newItemId);
+    document.querySelector('.detail-title-input')?.select();
     if (typeof loadStats === 'function') loadStats();
   } catch (e) {
     $('statusMsg').textContent = 'Failed to create card: ' + e.message;


### PR DESCRIPTION
Closes #88

## Summary

When the user clicks **+ New card**, the detail panel now opens with the
`new card` placeholder title pre-selected in the title input. The first
keystroke replaces it — no extra click needed.

## Change

`createManualCard` in `web/page/index.html`:

- Awaits `openTodoDetail(newItemId)` so the detail panel's title input is
  guaranteed to be in the DOM before we try to focus it. This is correct
  on both the hot path (item already in `allAnalyses` after the preceding
  `loadItems()`) and the cold path (where `openTodoDetail` issues a
  `/analyses/<id>` fetch that a single animation frame would not wait for).
- Calls `.select()` on `.detail-title-input`, which focuses the input and
  highlights the placeholder text.

The issue suggested `requestAnimationFrame(...)` — using `await` instead
avoids a race on the cold-fetch path.

## Stacking

This PR branches off `fix/issue-85-card-parity` because `createManualCard`
was introduced in PR #89 and does not exist on `main` yet. GitHub will
auto-retarget this PR to `main` once #89 merges.

## Tests

`python3 -m pytest` — **472 passed in 22.92s** (matches the #85 branch
baseline; frontend-only change).

**Visual verification pending — automated agent. Manual browser check required before merge.**