### PR TITLE
Cascade-delete synthesized manual_<doc_id> items row on todo delete (parsival#92)

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1865,6 +1865,7 @@ def delete_todo(doc_id: int):
     """
     with db.lock:
         card_ids = db.get_cards_for_todo(doc_id)
+        todo = db.get_todo_by_id(doc_id)
         db.delete_todo_by_id(doc_id)
         for cid in card_ids:
             db.conn().execute(
@@ -1872,6 +1873,12 @@ def delete_todo(doc_id: int):
                 "WHERE card_id = ? AND link_type = 'todo' AND target_id = ?",
                 (cid, str(doc_id)),
             )
+        # Manual cards synthesize a `manual_<doc_id>` items row so the detail
+        # panel works for them (parsival#85). Drop that row when the todo goes
+        # away, otherwise the Items view keeps showing an orphan card until
+        # the row is purged some other way.
+        if todo and todo.get("item_id") == f"manual_{doc_id}":
+            db.delete_item_by_id(f"manual_{doc_id}")
     return Response(status_code=204)
 
 

--- a/api/db.py
+++ b/api/db.py
@@ -968,6 +968,11 @@ def delete_todo_by_id(todo_id: int) -> None:
     conn().execute("DELETE FROM todos WHERE id = ?", (todo_id,))
 
 
+def delete_item_by_id(item_id: str) -> None:
+    """Remove a single items row by its item_id."""
+    conn().execute("DELETE FROM items WHERE item_id = ?", (item_id,))
+
+
 def get_all_todos() -> list[dict]:
     """Return all todo rows (including done), ordered by priority then created_at."""
     return _rows_to_list(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -212,6 +212,45 @@ def test_delete_todo(client):
     assert todos.get(doc_id=doc_id) is None
 
 
+def test_delete_manual_todo_drops_synthesized_item(client):
+    """parsival#92: deleting a manual todo must also remove its synthesized
+    `manual_<doc_id>` items row, otherwise the Items view keeps showing an
+    orphan card after refresh."""
+    import db as _db
+    resp = client.post("/todos", json={"description": "manual to delete", "priority": "low"})
+    assert resp.status_code == 200
+    doc_id     = resp.json()["doc_id"]
+    synth_id   = f"manual_{doc_id}"
+    with _db.lock:
+        assert _db.get_item(synth_id) is not None
+    r = client.delete(f"/todos/{doc_id}")
+    assert r.status_code == 204
+    with _db.lock:
+        assert _db.get_item(synth_id) is None
+
+
+def test_delete_real_todo_keeps_underlying_item(client):
+    """Deleting a todo linked to a real (non-manual) item must NOT delete the
+    underlying email/intel row — only manual_<doc_id> synthetics cascade."""
+    import db as _db
+    with _db.lock:
+        _db.upsert_item({
+            "item_id": "real_keep", "source": "outlook",
+            "title": "real email", "body_preview": "hi",
+        })
+    resp = client.post("/todos", json={
+        "description": "review email",
+        "priority":    "medium",
+        "item_id":     "real_keep",
+    })
+    assert resp.status_code == 200
+    doc_id = resp.json()["doc_id"]
+    r = client.delete(f"/todos/{doc_id}")
+    assert r.status_code == 204
+    with _db.lock:
+        assert _db.get_item("real_keep") is not None
+
+
 def test_post_todo_creates_manual_item(client):
     r = client.post("/todos", json={"description": "Manual task", "priority": "high"})
     assert r.status_code == 200

--- a/web/page/index.html
+++ b/web/page/index.html
@@ -2591,14 +2591,29 @@ async function deleteTodo(id) {
   if (idx < 0) return;
   const original = allTodos[idx];
   _removeTodoRow(id);
+  // Manual cards live in two caches — `allTodos` (Todos view) and the
+  // synthesized `manual_<doc_id>` row in `allAnalyses` (Items view).
+  // Drop the synthesized row in lockstep so the Items view doesn't keep
+  // showing a ghost card until the next refresh (parsival#92).
+  const synthId = `manual_${id}`;
+  const aIdx = allAnalyses.findIndex(a => a.item_id === synthId);
+  const originalAnalysis = aIdx >= 0 ? allAnalyses[aIdx] : null;
+  if (aIdx >= 0) {
+    allAnalyses.splice(aIdx, 1);
+    if (currentView === 'items') renderItems(allAnalyses);
+  }
   try {
     await api(`/todos/${id}`, 'DELETE');
     loadStats();
   } catch (e) {
     console.warn('deleteTodo:', e);
-    // Revert: reinsert the row into the local cache and re-render the list.
+    // Revert: reinsert into both caches and re-render the affected views.
     // Full re-render is fine here — this only runs on the error path.
     allTodos.splice(Math.min(idx, allTodos.length), 0, original);
+    if (originalAnalysis) {
+      allAnalyses.splice(Math.min(aIdx, allAnalyses.length), 0, originalAnalysis);
+      if (currentView === 'items') renderItems(allAnalyses);
+    }
     const visible = _filterTodos(allTodos);
     renderTodos(visible);
     updateCounts(visible);


### PR DESCRIPTION
Closes #92

Manual cards exist in two caches: the `todos` table and a synthesized `manual_<doc_id>` row in the `items` table (parsival#85, so manual cards share the detail-panel + Items-view code path). `DELETE /todos/{id}` only removed the todo row, leaving the synthesized item orphaned. The Items view kept the ghost card until something else purged the row — page refresh did not help, since `/analyses` was still returning it.

This change makes the cleanup symmetric: `delete_todo` now also drops `items.item_id = manual_<doc_id>` when the todo's `item_id` matches that pattern, and `deleteTodo` in the frontend mirrors the cleanup on `allAnalyses` so the card disappears from the Items view in lockstep with the Todos view (with full revert on the error path). Real (non-manual) backing items are not touched.

## Test results
- New backend regression tests:
  - `test_delete_manual_todo_drops_synthesized_item`
  - `test_delete_real_todo_keeps_underlying_item`
- Full api suite: 474 passed (was 472 baseline + 2 new).

**Visual verification pending — automated agent. Manual browser check required before merge.**