### PR TITLE
feat(#43): lancellmot document chip on situation cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ All credentials can be set in `docker-compose.yml` under the `page-api` environm
 | `OLLAMA_URL`       | Ollama API endpoint (default: `http://host.docker.internal:11400/api/generate`)  |
 | `OLLAMA_MODEL`     | Model for extraction (default: `qwen3:32b`)                                     |
 | `MERLLM_URL`       | merLLM base URL for batch jobs (default: `http://host.docker.internal:11400`)    |
+| `LANCELLMOT_URL`   | lancellmot base URL for document linking (default: `http://host.docker.internal:8080`) |
 | `LOOKBACK_HOURS`   | Hours of history per scan (default: `48`)                                        |
 | `CREDENTIALS_KEY`  | Passphrase for Fernet encryption of OAuth tokens at rest. Leave unset for plaintext (backward compatible). Changing this key after tokens are stored makes them unreadable. |
 
@@ -513,6 +514,33 @@ Cards can reach into the rest of Parsival's information stream:
 - **Filters.** The toolbar gained a "with external links" / "no linked context" filter so you can either focus on cards that already have their paperwork attached or hunt for the ones still waiting to be annotated.
 
 Jira sprint bridging (surfacing Jira issues on the board directly) is on hold until a Jira ingest path lands — until then, accepted item-links are the entry point for Jira-sourced context.
+
+## lancellmot document linking
+
+Situation cards surface a chip linking to related documents in
+[lancellmot](https://github.com/rcanterberryhall/hexcaliper-lanceLLMot), the
+ecosystem's document assistant. Resolution is through an explicit alias table —
+each Parsival project is mapped by hand to a lancellmot project in
+**Settings → Projects**. There is no fuzzy matching; the friction of mapping is
+the forcing function that keeps project naming disciplined.
+
+- **Setup.** Point `LANCELLMOT_URL` at your lancellmot instance (default
+  `http://host.docker.internal:8080`).
+- **Mapping.** Open Settings → Projects and pick a lancellmot project from the
+  dropdown on each project row. The choice persists immediately.
+- **Resolved chip.** A situation tagged with a mapped project shows a chip with
+  the document count; hover it for a popover listing the top filenames.
+- **Unmapped chip.** A tag with no mapping shows a dashed `Map →` chip; clicking
+  it opens Settings focused on that project row.
+- **Unreachable chip.** If lancellmot can't be reached the chip renders amber
+  with an `⚠ unreachable` label — failures are loud, never silent. Click to
+  retry.
+
+The chip popover lists filenames for context. Deep-linking into lancellmot's
+document viewer is gated behind an optional `window.LANCELLMOT_WEB_URL` global:
+when a browser-facing lancellmot URL is configured, the popover gains an
+"Open lancellmot →" link; otherwise filenames render as plain text so the chip
+never points at a route that doesn't exist.
 
 ## Seed workflow
 

--- a/api/app.py
+++ b/api/app.py
@@ -55,11 +55,13 @@ from typing import Optional
 import requests as http_requests
 from fastapi import BackgroundTasks, FastAPI, HTTPException, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
 import config
 import crypto
 import db
+import lancellmot_client
 from agent import extract_keywords, extract_emails, resolve_owner_email, generate_project_briefing
 from models import RawItem, Analysis
 import contacts as _contacts
@@ -4032,3 +4034,71 @@ def lookahead_reject_suggestion(suggestion_id: int):
     if not row:
         raise HTTPException(status_code=404, detail="suggestion not found")
     return row
+
+
+# ── lancellmot document linking (parsival#43) ────────────────────────────────────
+
+@app.get("/lancellmot/aliases")
+def list_lancellmot_aliases_route():
+    """List all parsival-project → lancellmot-project aliases (Settings audit)."""
+    with db.lock:
+        return db.list_lancellmot_aliases()
+
+
+@app.put("/lancellmot/aliases")
+def put_lancellmot_alias(payload: dict):
+    """Upsert a single project-tag → lancellmot-project alias."""
+    try:
+        parsival = payload["parsival_project"]
+        lid = payload["lancellmot_project_id"]
+        lname = payload["lancellmot_project_name"]
+    except KeyError as exc:
+        raise HTTPException(status_code=400, detail=f"missing field: {exc}")
+    with db.lock:
+        db.upsert_lancellmot_alias(parsival, lid, lname)
+    return {"ok": True}
+
+
+@app.delete("/lancellmot/aliases/{parsival_project}")
+def delete_lancellmot_alias_route(parsival_project: str):
+    """Remove a project-tag alias."""
+    with db.lock:
+        db.delete_lancellmot_alias(parsival_project)
+    return {"ok": True}
+
+
+@app.get("/lancellmot/projects")
+def get_lancellmot_projects():
+    """Proxy lancellmot's project list (populates the Settings dropdown)."""
+    try:
+        return lancellmot_client.list_projects()
+    except lancellmot_client.LancellmotUnavailable:
+        return JSONResponse(status_code=503, content={"error": "unreachable"})
+
+
+@app.get("/lancellmot/docs-for-tag")
+def docs_for_tag(tag: str, limit: int = 5):
+    """Resolve a project tag to its lancellmot documents for the card chip.
+
+    Returns one of three shapes the UI renders as distinct chip states:
+    ``ok`` (resolved, with docs), ``unmapped`` (no alias), or ``unreachable``
+    (lancellmot down). The DB lookup holds ``db.lock``; the network call does
+    not, so a slow lancellmot never blocks other DB work.
+    """
+    with db.lock:
+        alias = db.get_lancellmot_alias_for_tag(tag)
+    if alias is None:
+        return {"status": "unmapped", "tag": tag}
+    try:
+        docs = lancellmot_client.list_documents(
+            alias["lancellmot_project_id"], limit=limit
+        )
+    except lancellmot_client.LancellmotUnavailable:
+        return {"status": "unreachable", "tag": tag}
+    return {
+        "status": "ok",
+        "tag": tag,
+        "project_id": alias["lancellmot_project_id"],
+        "project_name": alias["lancellmot_project_name"],
+        "docs": docs,
+    }

--- a/api/config.py
+++ b/api/config.py
@@ -78,6 +78,7 @@ CREDENTIALS_KEY = _get("CREDENTIALS_KEY", "")
 OLLAMA_URL   = _get("OLLAMA_URL",   "http://host.docker.internal:11400/api/generate")
 OLLAMA_MODEL = _get("OLLAMA_MODEL", "qwen3:32b")
 MERLLM_URL   = _get("MERLLM_URL",   "http://host.docker.internal:11400")
+LANCELLMOT_URL = _get("LANCELLMOT_URL", "http://host.docker.internal:8080")
 
 # Cloudflare Access service token for authenticating requests to Ollama.
 CF_CLIENT_ID     = _get("CF_CLIENT_ID")

--- a/api/db.py
+++ b/api/db.py
@@ -245,6 +245,19 @@ def _migrate_schema(c: sqlite3.Connection) -> None:
     """)
     c.execute("CREATE INDEX IF NOT EXISTS idx_slack_seen_chan ON slack_seen_messages(channel_id)")
 
+    # Explicit project-tag → lancellmot-project mapping (parsival#43).  Strict
+    # alias table, no fuzzy matching: each parsival project name is hand-mapped
+    # to a lancellmot project so situation cards can surface related documents.
+    c.execute("""
+        CREATE TABLE IF NOT EXISTS lancellmot_aliases (
+            parsival_project          TEXT PRIMARY KEY,
+            lancellmot_project_id     TEXT NOT NULL,
+            lancellmot_project_name   TEXT NOT NULL,
+            created_at                TEXT NOT NULL,
+            updated_at                TEXT NOT NULL
+        )
+    """)
+
 
 def _create_schema(c: sqlite3.Connection) -> None:
     """Create all tables and indexes if they do not already exist."""
@@ -1154,6 +1167,58 @@ def set_model_state(key: str, value: dict) -> None:
         "INSERT INTO model_state (key, value) VALUES (?,?) "
         "ON CONFLICT(key) DO UPDATE SET value=excluded.value",
         (key, json.dumps(value)),
+    )
+
+
+# ── lancellmot project aliases (parsival#43) ─────────────────────────────────────
+
+def upsert_lancellmot_alias(
+    parsival_project: str,
+    lancellmot_project_id: str,
+    lancellmot_project_name: str,
+) -> None:
+    """Create or update the lancellmot mapping for a parsival project name."""
+    now = _now_iso()
+    conn().execute(
+        "INSERT INTO lancellmot_aliases "
+        "(parsival_project, lancellmot_project_id, lancellmot_project_name, "
+        " created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT(parsival_project) DO UPDATE SET "
+        "  lancellmot_project_id = excluded.lancellmot_project_id, "
+        "  lancellmot_project_name = excluded.lancellmot_project_name, "
+        "  updated_at = excluded.updated_at",
+        (parsival_project, lancellmot_project_id, lancellmot_project_name, now, now),
+    )
+
+
+def get_lancellmot_alias_for_tag(parsival_project: str) -> Optional[dict]:
+    """Return the alias row for a project name, or None if unmapped."""
+    row = conn().execute(
+        "SELECT parsival_project, lancellmot_project_id, lancellmot_project_name, "
+        "       created_at, updated_at "
+        "FROM lancellmot_aliases WHERE parsival_project = ?",
+        (parsival_project,),
+    ).fetchone()
+    return dict(row) if row else None
+
+
+def list_lancellmot_aliases() -> list[dict]:
+    """Return all alias rows ordered by parsival project name."""
+    rows = conn().execute(
+        "SELECT parsival_project, lancellmot_project_id, lancellmot_project_name, "
+        "       created_at, updated_at "
+        "FROM lancellmot_aliases "
+        "ORDER BY parsival_project"
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+def delete_lancellmot_alias(parsival_project: str) -> None:
+    """Remove the alias for a project name; a no-op if it does not exist."""
+    conn().execute(
+        "DELETE FROM lancellmot_aliases WHERE parsival_project = ?",
+        (parsival_project,),
     )
 
 

--- a/api/lancellmot_client.py
+++ b/api/lancellmot_client.py
@@ -1,0 +1,44 @@
+"""HTTP client for lancellmot's workspace + documents API (parsival#43).
+
+Used by parsival to resolve project tags to lancellmot projects and fetch
+related documents for the situation-card chip. Failures (network error,
+timeout, non-2xx) raise ``LancellmotUnavailable`` so callers can render the
+amber "unreachable" chip state instead of silently hiding the link.
+"""
+import requests
+
+import config
+
+
+DEFAULT_TIMEOUT = 2.0
+
+
+class LancellmotUnavailable(Exception):
+    """Raised on network error, timeout, or non-2xx response from lancellmot."""
+
+
+def list_projects() -> list[dict]:
+    """Return all lancellmot projects. Raises LancellmotUnavailable on failure."""
+    url = f"{config.LANCELLMOT_URL}/workspace/projects"
+    try:
+        resp = requests.get(url, timeout=DEFAULT_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+    except (requests.RequestException, ValueError) as exc:
+        raise LancellmotUnavailable(str(exc)) from exc
+
+
+def list_documents(project_id: str, limit: int = 5) -> list[dict]:
+    """Return the first ``limit`` documents for a lancellmot project.
+
+    Raises LancellmotUnavailable on network error, timeout, or non-2xx response.
+    """
+    url = f"{config.LANCELLMOT_URL}/documents"
+    params = {"project_id": project_id}
+    try:
+        resp = requests.get(url, params=params, timeout=DEFAULT_TIMEOUT)
+        resp.raise_for_status()
+        docs = resp.json()
+    except (requests.RequestException, ValueError) as exc:
+        raise LancellmotUnavailable(str(exc)) from exc
+    return docs[:limit]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       PYTHONUNBUFFERED:  "1"
       OLLAMA_URL:       "http://host.docker.internal:11400/api/generate"
       MERLLM_URL:       "http://host.docker.internal:11400"
+      LANCELLMOT_URL:   "http://host.docker.internal:8080"
       OLLAMA_MODEL:     "qwen3:32b"
       CF_CLIENT_ID:     ""
       CF_CLIENT_SECRET: ""

--- a/docs/superpowers/plans/2026-04-19-parsival-lancellmot-document-chip.md
+++ b/docs/superpowers/plans/2026-04-19-parsival-lancellmot-document-chip.md
@@ -1,0 +1,1194 @@
+# Parsival → lancellmot Document Chip Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a "Related in lancellmot" chip to parsival situation cards that resolves project tags to lancellmot projects via a strict alias table and surfaces top documents inline.
+
+**Architecture:** New `lancellmot_aliases` SQLite table stores explicit project-name → lancellmot-project-id mappings. New `api/lancellmot_client.py` wraps lancellmot's HTTP API. Five new FastAPI routes expose CRUD for aliases, a projects proxy (for the Settings dropdown), and `docs-for-tag` (the render path). UI adds a dropdown column to each Settings project row and a chip (with three visual states: resolved, unmapped, unreachable) on each situation card.
+
+**Tech Stack:** Python 3.11+, FastAPI, SQLite (via `api/db.py`), `requests` for HTTP, vanilla JS for UI (existing `web/page/index.html`), pytest + httpx mocking.
+
+**Spec:** `docs/superpowers/specs/2026-04-19-parsival-lancellmot-document-chip-design.md`
+**Issue:** [parsival#43](https://github.com/rcanterberryhall/hexcaliper-parsival/issues/43)
+
+---
+
+## File Structure
+
+| File | Role |
+|---|---|
+| `api/config.py` | Add `LANCELLMOT_URL` env var |
+| `api/db.py` | Add `lancellmot_aliases` table + 4 CRUD helpers |
+| `api/lancellmot_client.py` | NEW — HTTP client (list_projects, list_documents, LancellmotUnavailable) |
+| `api/app.py` | Add 5 routes under `/api/lancellmot/*` |
+| `web/page/index.html` | Settings dropdown column + situation-card chip |
+| `docker-compose.yml` | Wire `LANCELLMOT_URL` env into parsival-api service |
+| `tests/test_lancellmot_aliases.py` | NEW — DB CRUD tests |
+| `tests/test_lancellmot_client.py` | NEW — HTTP client tests |
+| `tests/test_lancellmot_routes.py` | NEW — route integration tests |
+| `README.md` | Document the feature |
+
+---
+
+## Task 1: Config + schema migration
+
+**Files:**
+- Modify: `api/config.py`
+- Modify: `api/db.py` (init function, around line 240)
+- Modify: `docker-compose.yml`
+- Test: `tests/test_lancellmot_aliases.py` (NEW)
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/test_lancellmot_aliases.py`:
+
+```python
+"""Tests for lancellmot_aliases table + CRUD helpers."""
+from api import db
+
+
+def test_lancellmot_aliases_table_exists():
+    cols = {r[1] for r in db.conn().execute(
+        "PRAGMA table_info(lancellmot_aliases)"
+    ).fetchall()}
+    assert cols == {
+        "parsival_project",
+        "lancellmot_project_id",
+        "lancellmot_project_name",
+        "created_at",
+        "updated_at",
+    }
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_lancellmot_aliases.py -v`
+Expected: FAIL with empty set (table missing)
+
+- [ ] **Step 3: Add table to db.py init**
+
+In `api/db.py`, find the init function's `CREATE TABLE` block (around line 240, near existing tables). Add:
+
+```python
+    CREATE TABLE IF NOT EXISTS lancellmot_aliases (
+        parsival_project          TEXT PRIMARY KEY,
+        lancellmot_project_id     TEXT NOT NULL,
+        lancellmot_project_name   TEXT NOT NULL,
+        created_at                TEXT NOT NULL,
+        updated_at                TEXT NOT NULL
+    );
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_lancellmot_aliases.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Add LANCELLMOT_URL to config.py**
+
+In `api/config.py`, just after the `MERLLM_URL` line (~line 80):
+
+```python
+LANCELLMOT_URL = _get("LANCELLMOT_URL", "http://host.docker.internal:8080")
+```
+
+- [ ] **Step 6: Wire env var in docker-compose.yml**
+
+Find the parsival-api `environment:` block and add:
+
+```yaml
+      LANCELLMOT_URL:   "http://host.docker.internal:8080"
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add api/config.py api/db.py docker-compose.yml tests/test_lancellmot_aliases.py
+git commit -m "feat(#43): add lancellmot_aliases table + LANCELLMOT_URL config"
+```
+
+---
+
+## Task 2: DB CRUD helpers for aliases
+
+**Files:**
+- Modify: `api/db.py` (append helpers at module scope, near other CRUD helpers)
+- Test: `tests/test_lancellmot_aliases.py`
+
+- [ ] **Step 1: Write failing test for upsert + get_by_tag**
+
+Append to `tests/test_lancellmot_aliases.py`:
+
+```python
+def test_upsert_creates_alias():
+    db.upsert_lancellmot_alias(
+        parsival_project="Ethylene-Cracker-3",
+        lancellmot_project_id="proj-123",
+        lancellmot_project_name="ethylene-cracker-3",
+    )
+    row = db.get_lancellmot_alias_for_tag("Ethylene-Cracker-3")
+    assert row is not None
+    assert row["lancellmot_project_id"] == "proj-123"
+    assert row["lancellmot_project_name"] == "ethylene-cracker-3"
+    assert row["created_at"]
+    assert row["updated_at"]
+
+
+def test_upsert_updates_existing_alias():
+    db.upsert_lancellmot_alias(
+        parsival_project="Alpha",
+        lancellmot_project_id="old-id",
+        lancellmot_project_name="old-name",
+    )
+    original = db.get_lancellmot_alias_for_tag("Alpha")
+    db.upsert_lancellmot_alias(
+        parsival_project="Alpha",
+        lancellmot_project_id="new-id",
+        lancellmot_project_name="new-name",
+    )
+    updated = db.get_lancellmot_alias_for_tag("Alpha")
+    assert updated["lancellmot_project_id"] == "new-id"
+    assert updated["lancellmot_project_name"] == "new-name"
+    assert updated["created_at"] == original["created_at"]
+    assert updated["updated_at"] >= original["updated_at"]
+
+
+def test_get_lancellmot_alias_returns_none_for_missing():
+    assert db.get_lancellmot_alias_for_tag("Nonexistent") is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_lancellmot_aliases.py -v`
+Expected: FAIL — `AttributeError: module 'api.db' has no attribute 'upsert_lancellmot_alias'`
+
+- [ ] **Step 3: Implement upsert + get_by_tag**
+
+Append to `api/db.py` (at module scope, after existing CRUD helpers):
+
+```python
+def upsert_lancellmot_alias(
+    parsival_project: str,
+    lancellmot_project_id: str,
+    lancellmot_project_name: str,
+) -> None:
+    now = datetime.utcnow().isoformat()
+    conn().execute(
+        "INSERT INTO lancellmot_aliases "
+        "(parsival_project, lancellmot_project_id, lancellmot_project_name, "
+        " created_at, updated_at) "
+        "VALUES (?, ?, ?, ?, ?) "
+        "ON CONFLICT(parsival_project) DO UPDATE SET "
+        "  lancellmot_project_id = excluded.lancellmot_project_id, "
+        "  lancellmot_project_name = excluded.lancellmot_project_name, "
+        "  updated_at = excluded.updated_at",
+        (parsival_project, lancellmot_project_id, lancellmot_project_name, now, now),
+    )
+    conn().commit()
+
+
+def get_lancellmot_alias_for_tag(parsival_project: str) -> dict | None:
+    row = conn().execute(
+        "SELECT parsival_project, lancellmot_project_id, lancellmot_project_name, "
+        "       created_at, updated_at "
+        "FROM lancellmot_aliases WHERE parsival_project = ?",
+        (parsival_project,),
+    ).fetchone()
+    if row is None:
+        return None
+    return {
+        "parsival_project": row[0],
+        "lancellmot_project_id": row[1],
+        "lancellmot_project_name": row[2],
+        "created_at": row[3],
+        "updated_at": row[4],
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_lancellmot_aliases.py -v`
+Expected: PASS (all 4 tests)
+
+- [ ] **Step 5: Write failing tests for list + delete**
+
+Append:
+
+```python
+def test_list_lancellmot_aliases_returns_all():
+    db.upsert_lancellmot_alias("A", "idA", "nameA")
+    db.upsert_lancellmot_alias("B", "idB", "nameB")
+    rows = db.list_lancellmot_aliases()
+    names = {r["parsival_project"] for r in rows}
+    assert {"A", "B"}.issubset(names)
+
+
+def test_delete_lancellmot_alias_removes_row():
+    db.upsert_lancellmot_alias("Doomed", "id-doom", "name-doom")
+    assert db.get_lancellmot_alias_for_tag("Doomed") is not None
+    db.delete_lancellmot_alias("Doomed")
+    assert db.get_lancellmot_alias_for_tag("Doomed") is None
+
+
+def test_delete_lancellmot_alias_missing_is_noop():
+    db.delete_lancellmot_alias("Never-Existed")  # must not raise
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_lancellmot_aliases.py -v`
+Expected: FAIL — missing `list_lancellmot_aliases` / `delete_lancellmot_alias`
+
+- [ ] **Step 7: Implement list + delete**
+
+Append to `api/db.py`:
+
+```python
+def list_lancellmot_aliases() -> list[dict]:
+    rows = conn().execute(
+        "SELECT parsival_project, lancellmot_project_id, lancellmot_project_name, "
+        "       created_at, updated_at "
+        "FROM lancellmot_aliases "
+        "ORDER BY parsival_project"
+    ).fetchall()
+    return [
+        {
+            "parsival_project": r[0],
+            "lancellmot_project_id": r[1],
+            "lancellmot_project_name": r[2],
+            "created_at": r[3],
+            "updated_at": r[4],
+        }
+        for r in rows
+    ]
+
+
+def delete_lancellmot_alias(parsival_project: str) -> None:
+    conn().execute(
+        "DELETE FROM lancellmot_aliases WHERE parsival_project = ?",
+        (parsival_project,),
+    )
+    conn().commit()
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_lancellmot_aliases.py -v`
+Expected: PASS (all 7 tests)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add api/db.py tests/test_lancellmot_aliases.py
+git commit -m "feat(#43): CRUD helpers for lancellmot_aliases"
+```
+
+---
+
+## Task 3: HTTP client (api/lancellmot_client.py)
+
+**Files:**
+- Create: `api/lancellmot_client.py`
+- Create: `tests/test_lancellmot_client.py`
+
+- [ ] **Step 1: Write failing test for list_projects success**
+
+Create `tests/test_lancellmot_client.py`:
+
+```python
+"""Tests for api.lancellmot_client."""
+from unittest.mock import patch, MagicMock
+import pytest
+from api import lancellmot_client
+
+
+def _ok_response(payload):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_list_projects_returns_list_of_dicts():
+    payload = [
+        {"id": "p1", "name": "alpha"},
+        {"id": "p2", "name": "beta"},
+    ]
+    with patch("api.lancellmot_client.requests.get",
+               return_value=_ok_response(payload)) as mock_get:
+        result = lancellmot_client.list_projects()
+    assert result == payload
+    call_url = mock_get.call_args[0][0]
+    assert "/workspace/projects" in call_url
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_lancellmot_client.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'api.lancellmot_client'`
+
+- [ ] **Step 3: Create the client module**
+
+Create `api/lancellmot_client.py`:
+
+```python
+"""HTTP client for lancellmot's workspace + documents API.
+
+Used by parsival to resolve project tags to lancellmot projects and fetch
+related documents for the situation-card chip.
+"""
+import requests
+
+from api import config
+
+
+DEFAULT_TIMEOUT = 2.0
+
+
+class LancellmotUnavailable(Exception):
+    """Raised on network error, timeout, or non-2xx response from lancellmot."""
+
+
+def list_projects() -> list[dict]:
+    """Return all lancellmot projects. Raises LancellmotUnavailable on failure."""
+    url = f"{config.LANCELLMOT_URL}/workspace/projects"
+    try:
+        resp = requests.get(url, timeout=DEFAULT_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+    except (requests.RequestException, ValueError) as exc:
+        raise LancellmotUnavailable(str(exc)) from exc
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_lancellmot_client.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing tests for failure modes**
+
+Append to `tests/test_lancellmot_client.py`:
+
+```python
+def test_list_projects_raises_on_network_error():
+    with patch("api.lancellmot_client.requests.get",
+               side_effect=__import__("requests").ConnectionError("boom")):
+        with pytest.raises(lancellmot_client.LancellmotUnavailable):
+            lancellmot_client.list_projects()
+
+
+def test_list_projects_raises_on_timeout():
+    with patch("api.lancellmot_client.requests.get",
+               side_effect=__import__("requests").Timeout("slow")):
+        with pytest.raises(lancellmot_client.LancellmotUnavailable):
+            lancellmot_client.list_projects()
+
+
+def test_list_projects_raises_on_5xx():
+    bad = MagicMock()
+    bad.status_code = 503
+    bad.raise_for_status.side_effect = __import__("requests").HTTPError("503")
+    with patch("api.lancellmot_client.requests.get", return_value=bad):
+        with pytest.raises(lancellmot_client.LancellmotUnavailable):
+            lancellmot_client.list_projects()
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_lancellmot_client.py -v`
+Expected: PASS (existing try/except already covers these paths)
+
+- [ ] **Step 7: Write failing test for list_documents**
+
+Append:
+
+```python
+def test_list_documents_returns_trimmed_list():
+    payload = [{"id": f"d{i}", "filename": f"doc{i}.pdf"} for i in range(10)]
+    with patch("api.lancellmot_client.requests.get",
+               return_value=_ok_response(payload)) as mock_get:
+        result = lancellmot_client.list_documents("proj-1", limit=5)
+    assert len(result) == 5
+    assert result[0]["filename"] == "doc0.pdf"
+    call_url = mock_get.call_args[0][0]
+    assert "/documents" in call_url
+    assert "project_id=proj-1" in call_url
+
+
+def test_list_documents_default_limit_is_5():
+    payload = [{"id": f"d{i}", "filename": f"doc{i}.pdf"} for i in range(20)]
+    with patch("api.lancellmot_client.requests.get",
+               return_value=_ok_response(payload)):
+        result = lancellmot_client.list_documents("proj-1")
+    assert len(result) == 5
+
+
+def test_list_documents_raises_on_failure():
+    with patch("api.lancellmot_client.requests.get",
+               side_effect=__import__("requests").ConnectionError("boom")):
+        with pytest.raises(lancellmot_client.LancellmotUnavailable):
+            lancellmot_client.list_documents("proj-1")
+```
+
+- [ ] **Step 8: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_lancellmot_client.py -v`
+Expected: FAIL — `AttributeError: module 'api.lancellmot_client' has no attribute 'list_documents'`
+
+- [ ] **Step 9: Implement list_documents**
+
+Append to `api/lancellmot_client.py`:
+
+```python
+def list_documents(project_id: str, limit: int = 5) -> list[dict]:
+    """Return first `limit` documents for a lancellmot project.
+
+    Raises LancellmotUnavailable on network error, timeout, or non-2xx response.
+    """
+    url = f"{config.LANCELLMOT_URL}/documents"
+    params = {"project_id": project_id}
+    try:
+        resp = requests.get(url, params=params, timeout=DEFAULT_TIMEOUT)
+        resp.raise_for_status()
+        docs = resp.json()
+    except (requests.RequestException, ValueError) as exc:
+        raise LancellmotUnavailable(str(exc)) from exc
+    return docs[:limit]
+```
+
+Note: the test asserts `project_id=proj-1` appears in the URL. `requests` serializes params into the query string, so this works.
+
+- [ ] **Step 10: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_lancellmot_client.py -v`
+Expected: PASS (all 6 tests)
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add api/lancellmot_client.py tests/test_lancellmot_client.py
+git commit -m "feat(#43): HTTP client for lancellmot projects + documents"
+```
+
+---
+
+## Task 4: Alias CRUD routes + projects proxy
+
+**Files:**
+- Modify: `api/app.py` (add 4 new routes near other `/api/*` groupings)
+- Create: `tests/test_lancellmot_routes.py`
+
+- [ ] **Step 1: Write failing test for GET /api/lancellmot/aliases**
+
+Create `tests/test_lancellmot_routes.py`:
+
+```python
+"""Integration tests for /api/lancellmot/* routes."""
+from unittest.mock import patch
+from fastapi.testclient import TestClient
+
+from api.app import app
+from api import db, lancellmot_client
+
+
+client = TestClient(app)
+
+
+def test_get_aliases_returns_list():
+    db.upsert_lancellmot_alias("Foo", "id-foo", "foo-name")
+    db.upsert_lancellmot_alias("Bar", "id-bar", "bar-name")
+    resp = client.get("/api/lancellmot/aliases")
+    assert resp.status_code == 200
+    body = resp.json()
+    names = {a["parsival_project"] for a in body}
+    assert {"Foo", "Bar"}.issubset(names)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/test_lancellmot_routes.py -v`
+Expected: FAIL — 404 (route missing)
+
+- [ ] **Step 3: Implement the route**
+
+In `api/app.py`, add near the other settings-adjacent routes (e.g. after the `/noise-filters` group, around line 1510):
+
+```python
+@app.get("/api/lancellmot/aliases")
+def list_lancellmot_aliases_route():
+    return db.list_lancellmot_aliases()
+```
+
+Ensure `from api import lancellmot_client` is imported at top of app.py (near other api imports).
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/test_lancellmot_routes.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Write failing tests for PUT + DELETE**
+
+Append:
+
+```python
+def test_put_alias_creates_new():
+    resp = client.put("/api/lancellmot/aliases", json={
+        "parsival_project": "NewProj",
+        "lancellmot_project_id": "id-new",
+        "lancellmot_project_name": "new-name",
+    })
+    assert resp.status_code == 200
+    row = db.get_lancellmot_alias_for_tag("NewProj")
+    assert row["lancellmot_project_id"] == "id-new"
+
+
+def test_put_alias_updates_existing():
+    db.upsert_lancellmot_alias("Upd", "old-id", "old-name")
+    resp = client.put("/api/lancellmot/aliases", json={
+        "parsival_project": "Upd",
+        "lancellmot_project_id": "new-id",
+        "lancellmot_project_name": "new-name",
+    })
+    assert resp.status_code == 200
+    row = db.get_lancellmot_alias_for_tag("Upd")
+    assert row["lancellmot_project_id"] == "new-id"
+
+
+def test_delete_alias_removes():
+    db.upsert_lancellmot_alias("Gone", "id-g", "g-name")
+    resp = client.delete("/api/lancellmot/aliases/Gone")
+    assert resp.status_code == 200
+    assert db.get_lancellmot_alias_for_tag("Gone") is None
+```
+
+- [ ] **Step 6: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_lancellmot_routes.py -v`
+Expected: FAIL (405 or 404 — routes missing)
+
+- [ ] **Step 7: Implement PUT + DELETE**
+
+Append in `api/app.py`:
+
+```python
+@app.put("/api/lancellmot/aliases")
+def put_lancellmot_alias(payload: dict):
+    try:
+        parsival = payload["parsival_project"]
+        lid = payload["lancellmot_project_id"]
+        lname = payload["lancellmot_project_name"]
+    except KeyError as k:
+        raise HTTPException(status_code=400, detail=f"missing field: {k}")
+    db.upsert_lancellmot_alias(parsival, lid, lname)
+    return {"ok": True}
+
+
+@app.delete("/api/lancellmot/aliases/{parsival_project}")
+def delete_lancellmot_alias_route(parsival_project: str):
+    db.delete_lancellmot_alias(parsival_project)
+    return {"ok": True}
+```
+
+Verify `HTTPException` is already imported at the top of `api/app.py`; if not, add it to the existing fastapi import line.
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_lancellmot_routes.py -v`
+Expected: PASS (4 tests)
+
+- [ ] **Step 9: Write failing tests for projects proxy**
+
+Append:
+
+```python
+def test_get_lancellmot_projects_proxies_client():
+    fake_projects = [{"id": "p1", "name": "alpha"}, {"id": "p2", "name": "beta"}]
+    with patch("api.app.lancellmot_client.list_projects",
+               return_value=fake_projects):
+        resp = client.get("/api/lancellmot/projects")
+    assert resp.status_code == 200
+    assert resp.json() == fake_projects
+
+
+def test_get_lancellmot_projects_503_on_unavailable():
+    with patch("api.app.lancellmot_client.list_projects",
+               side_effect=lancellmot_client.LancellmotUnavailable("boom")):
+        resp = client.get("/api/lancellmot/projects")
+    assert resp.status_code == 503
+    assert resp.json() == {"error": "unreachable"}
+```
+
+- [ ] **Step 10: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_lancellmot_routes.py -v`
+Expected: FAIL — route missing (404)
+
+- [ ] **Step 11: Implement projects proxy route**
+
+Append in `api/app.py`:
+
+```python
+@app.get("/api/lancellmot/projects")
+def get_lancellmot_projects():
+    try:
+        return lancellmot_client.list_projects()
+    except lancellmot_client.LancellmotUnavailable:
+        return JSONResponse(status_code=503, content={"error": "unreachable"})
+```
+
+Verify `JSONResponse` is imported (`from fastapi.responses import JSONResponse`). If not, add it.
+
+- [ ] **Step 12: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_lancellmot_routes.py -v`
+Expected: PASS (6 tests)
+
+- [ ] **Step 13: Commit**
+
+```bash
+git add api/app.py tests/test_lancellmot_routes.py
+git commit -m "feat(#43): alias CRUD routes + lancellmot projects proxy"
+```
+
+---
+
+## Task 5: docs-for-tag route (render path)
+
+**Files:**
+- Modify: `api/app.py`
+- Modify: `tests/test_lancellmot_routes.py`
+
+- [ ] **Step 1: Write failing test for resolved (ok) path**
+
+Append to `tests/test_lancellmot_routes.py`:
+
+```python
+def test_docs_for_tag_ok_path():
+    db.upsert_lancellmot_alias("Alpha", "proj-a", "alpha-proj")
+    fake_docs = [
+        {"id": "d1", "filename": "spec.pdf"},
+        {"id": "d2", "filename": "procedure.md"},
+    ]
+    with patch("api.app.lancellmot_client.list_documents",
+               return_value=fake_docs) as mock_docs:
+        resp = client.get("/api/lancellmot/docs-for-tag?tag=Alpha")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["project_name"] == "alpha-proj"
+    assert body["project_id"] == "proj-a"
+    assert body["docs"] == fake_docs
+    mock_docs.assert_called_once_with("proj-a", limit=5)
+
+
+def test_docs_for_tag_unmapped():
+    resp = client.get("/api/lancellmot/docs-for-tag?tag=NoAlias")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "unmapped"
+    assert body["tag"] == "NoAlias"
+
+
+def test_docs_for_tag_unreachable():
+    db.upsert_lancellmot_alias("Beta", "proj-b", "beta-proj")
+    with patch("api.app.lancellmot_client.list_documents",
+               side_effect=lancellmot_client.LancellmotUnavailable("down")):
+        resp = client.get("/api/lancellmot/docs-for-tag?tag=Beta")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "unreachable"
+    assert body["tag"] == "Beta"
+
+
+def test_docs_for_tag_respects_limit_param():
+    db.upsert_lancellmot_alias("Gamma", "proj-g", "gamma-proj")
+    with patch("api.app.lancellmot_client.list_documents",
+               return_value=[]) as mock_docs:
+        resp = client.get("/api/lancellmot/docs-for-tag?tag=Gamma&limit=3")
+    assert resp.status_code == 200
+    mock_docs.assert_called_once_with("proj-g", limit=3)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/test_lancellmot_routes.py -v`
+Expected: FAIL (404 — route missing)
+
+- [ ] **Step 3: Implement the route**
+
+Append in `api/app.py`:
+
+```python
+@app.get("/api/lancellmot/docs-for-tag")
+def docs_for_tag(tag: str, limit: int = 5):
+    alias = db.get_lancellmot_alias_for_tag(tag)
+    if alias is None:
+        return {"status": "unmapped", "tag": tag}
+    try:
+        docs = lancellmot_client.list_documents(
+            alias["lancellmot_project_id"], limit=limit
+        )
+    except lancellmot_client.LancellmotUnavailable:
+        return {"status": "unreachable", "tag": tag}
+    return {
+        "status": "ok",
+        "tag": tag,
+        "project_id": alias["lancellmot_project_id"],
+        "project_name": alias["lancellmot_project_name"],
+        "docs": docs,
+    }
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/test_lancellmot_routes.py -v`
+Expected: PASS (10 tests total in this file)
+
+- [ ] **Step 5: Run full test suite to check for regressions**
+
+Run: `python3 -m pytest tests/ -v`
+Expected: all tests PASS (~460+ with new additions)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add api/app.py tests/test_lancellmot_routes.py
+git commit -m "feat(#43): /api/lancellmot/docs-for-tag endpoint"
+```
+
+---
+
+## Task 6: Settings UI — Projects dropdown column
+
+**Files:**
+- Modify: `web/page/index.html`
+
+This task has no unit tests (pure HTML/JS). Verification is manual via browser after `docker compose up -d --build parsival-api`.
+
+- [ ] **Step 1: Add the dropdown column to project-list header + rows**
+
+In `web/page/index.html` near line 1508:
+
+```html
+<div class="project-row-head" id="project-list-head" style="display:none">
+  <span>Name / Parent</span><span>Description</span><span>Keywords</span><span>Senders</span><span>lancellmot</span><span></span>
+</div>
+```
+
+Find the JS function that builds each project row (search for `addProjectRow` and `renderProjects` or similar). Add a new `<select>` cell to each row's innerHTML. Example addition to the row template:
+
+```html
+<select class="lancellmot-select" data-parsival-project="${escapeHtml(p.name)}">
+  <option value="">— none —</option>
+</select>
+```
+
+- [ ] **Step 2: Add JS to populate dropdowns from /api/lancellmot/projects**
+
+Add to the settings-loading code (search for `loadSettings` or `openSettings`):
+
+```javascript
+async function populateLancellmotDropdowns() {
+  let projects = [];
+  try {
+    const r = await fetch('/api/lancellmot/projects');
+    if (!r.ok) throw new Error('unreachable');
+    projects = await r.json();
+  } catch (_) {
+    projects = null;  // will show as error state below
+  }
+  const aliasesResp = await fetch('/api/lancellmot/aliases');
+  const aliases = aliasesResp.ok ? await aliasesResp.json() : [];
+  const aliasByTag = {};
+  for (const a of aliases) aliasByTag[a.parsival_project] = a;
+
+  document.querySelectorAll('.lancellmot-select').forEach(sel => {
+    const parsivalProj = sel.dataset.parsivalProject;
+    sel.innerHTML = '';
+    const none = document.createElement('option');
+    none.value = '';
+    none.textContent = '— none —';
+    sel.appendChild(none);
+    if (projects === null) {
+      sel.disabled = true;
+      const err = document.createElement('option');
+      err.textContent = 'lancellmot unreachable';
+      err.disabled = true;
+      sel.appendChild(err);
+      return;
+    }
+    for (const p of projects) {
+      const o = document.createElement('option');
+      o.value = p.id;
+      o.textContent = p.name;
+      o.dataset.name = p.name;
+      sel.appendChild(o);
+    }
+    const current = aliasByTag[parsivalProj];
+    if (current) sel.value = current.lancellmot_project_id;
+
+    sel.addEventListener('change', async () => {
+      if (sel.value === '') {
+        await fetch('/api/lancellmot/aliases/' + encodeURIComponent(parsivalProj),
+                    { method: 'DELETE' });
+        return;
+      }
+      const picked = sel.options[sel.selectedIndex];
+      await fetch('/api/lancellmot/aliases', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          parsival_project: parsivalProj,
+          lancellmot_project_id: sel.value,
+          lancellmot_project_name: picked.dataset.name,
+        }),
+      });
+    });
+  });
+}
+```
+
+Call `populateLancellmotDropdowns()` from the end of the existing `renderProjects()` (or wherever project rows are rebuilt) AND from `openSettings()` after project rows render.
+
+- [ ] **Step 3: Add minimal CSS for the new column**
+
+Near the existing `.project-row-head` CSS, add:
+
+```css
+.lancellmot-select {
+  font-size: 11px;
+  padding: 3px 6px;
+  border-radius: var(--r);
+  border: 1px solid var(--border2);
+  background: var(--surface);
+  color: var(--text);
+  max-width: 160px;
+}
+```
+
+- [ ] **Step 4: Rebuild and visually verify**
+
+Run: `docker compose up -d --build parsival-api`
+
+Open the UI, click ⚙, scroll to Projects. For each project row:
+- Dropdown is present
+- Dropdown lists lancellmot projects
+- Selecting a project and reopening Settings shows it persisted
+- Selecting "— none —" removes the alias (visible via `curl /api/lancellmot/aliases`)
+- If lancellmot is down: dropdown shows "lancellmot unreachable" and is disabled
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/page/index.html
+git commit -m "feat(#43): Settings dropdown column for lancellmot project mapping"
+```
+
+---
+
+## Task 7: Situation card chip
+
+**Files:**
+- Modify: `web/page/index.html`
+
+No unit tests — verification via browser.
+
+- [ ] **Step 1: Add chip CSS**
+
+Add near other card chip styles:
+
+```css
+.lmot-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  border: 1px solid var(--border2);
+  background: rgba(64, 184, 255, 0.08);
+  color: var(--blue);
+  cursor: pointer;
+  margin-left: 6px;
+  position: relative;
+}
+.lmot-chip.unmapped {
+  background: transparent;
+  color: var(--muted);
+  border-color: var(--border2);
+  border-style: dashed;
+}
+.lmot-chip.unreachable {
+  background: rgba(255, 180, 60, 0.10);
+  color: #e6a23c;
+  border-color: #c07a1a;
+}
+.lmot-popover {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  min-width: 240px;
+  max-width: 320px;
+  background: var(--surface);
+  border: 1px solid var(--border2);
+  border-radius: 6px;
+  padding: 8px 10px;
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  font-size: 11px;
+}
+.lmot-popover a { display: block; padding: 2px 0; color: var(--blue); text-decoration: none; }
+.lmot-popover a:hover { text-decoration: underline; }
+.lmot-popover-head { color: var(--muted); font-weight: bold; margin-bottom: 4px; }
+```
+
+- [ ] **Step 2: Add chip-render JS**
+
+Add a helper function to the script section:
+
+```javascript
+async function renderLancellmotChips(situationCard, projectTags) {
+  // situationCard: DOM node of the card
+  // projectTags: array of parsival project name strings
+  if (!projectTags || projectTags.length === 0) return;
+  const host = situationCard.querySelector('.lmot-chip-host');
+  if (!host) return;  // card template missing the host element
+  host.innerHTML = '';
+  for (const tag of projectTags) {
+    const chip = document.createElement('span');
+    chip.className = 'lmot-chip';
+    chip.textContent = tag + ' · …';
+    host.appendChild(chip);
+    try {
+      const r = await fetch('/api/lancellmot/docs-for-tag?tag=' + encodeURIComponent(tag));
+      const body = await r.json();
+      if (body.status === 'ok') {
+        chip.textContent = tag + ' · ' + body.docs.length + ' doc' + (body.docs.length === 1 ? '' : 's');
+        chip.onmouseenter = () => showLancellmotPopover(chip, body);
+        chip.onmouseleave = () => hideLancellmotPopover(chip);
+        chip.onclick = () => window.open(
+          (window.LANCELLMOT_WEB_URL || '/lancellmot') + '/project/' + body.project_id,
+          '_blank');
+      } else if (body.status === 'unmapped') {
+        chip.classList.add('unmapped');
+        chip.textContent = tag + ' · Map →';
+        chip.title = 'No lancellmot mapping yet. Click to map.';
+        chip.onclick = () => openSettingsFocusedOn(tag);
+      } else {
+        chip.classList.add('unreachable');
+        chip.textContent = tag + ' · ⚠ unreachable';
+        chip.title = "Couldn't reach lancellmot — retry in a moment";
+        chip.onclick = () => renderLancellmotChips(situationCard, projectTags);
+      }
+    } catch (_) {
+      chip.classList.add('unreachable');
+      chip.textContent = tag + ' · ⚠ unreachable';
+    }
+  }
+}
+
+function showLancellmotPopover(chip, body) {
+  hideLancellmotPopover(chip);
+  const pop = document.createElement('div');
+  pop.className = 'lmot-popover';
+  const lmotWeb = window.LANCELLMOT_WEB_URL || '/lancellmot';
+  let html = '<div class="lmot-popover-head">' + escapeHtml(body.project_name) + '</div>';
+  for (const d of body.docs) {
+    html += '<a href="' + lmotWeb + '/document/' + encodeURIComponent(d.id) +
+            '" target="_blank">' + escapeHtml(d.filename) + '</a>';
+  }
+  html += '<a href="' + lmotWeb + '/project/' + encodeURIComponent(body.project_id) +
+          '" target="_blank" style="margin-top:4px;border-top:1px solid var(--border2);padding-top:4px">All docs in lancellmot →</a>';
+  pop.innerHTML = html;
+  chip.appendChild(pop);
+}
+
+function hideLancellmotPopover(chip) {
+  const existing = chip.querySelector('.lmot-popover');
+  if (existing) existing.remove();
+}
+```
+
+Note: if `escapeHtml` does not already exist in index.html, use the existing equivalent (search for how other card content sanitizes strings — likely a helper or `textContent` usage).
+
+- [ ] **Step 3: Add chip host element to situation card template**
+
+Find the situation-card rendering (search for `situation-card` or the function that builds situation cards). Add a host span near the project tag meta line:
+
+```html
+<span class="lmot-chip-host"></span>
+```
+
+After the card is appended to the DOM, call:
+
+```javascript
+renderLancellmotChips(cardEl, situation.project_tags || []);
+```
+
+Where `cardEl` is the card DOM node and `situation.project_tags` is the existing project tag array on the situation object.
+
+- [ ] **Step 4: Rebuild and visually verify all three chip states**
+
+Run: `docker compose up -d --build parsival-api`
+
+Verify in browser:
+- **Resolved:** situation tagged with a mapped project shows active chip; hover reveals popover with filenames; clicking a filename opens lancellmot doc viewer
+- **Unmapped:** situation tagged with an unmapped project shows dim "Map →" chip; clicking opens Settings with the right project row focused (Task 8 handles focus)
+- **Unreachable:** stop lancellmot container (`docker stop lancellmot-api` or equivalent); cards show amber "⚠ unreachable" chip; tooltip present; clicking re-fetches
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/page/index.html
+git commit -m "feat(#43): situation card lancellmot chip (resolved/unmapped/unreachable)"
+```
+
+---
+
+## Task 8: Click-through from unmapped chip to Settings
+
+**Files:**
+- Modify: `web/page/index.html`
+
+- [ ] **Step 1: Implement openSettingsFocusedOn(tag)**
+
+Add to the script section:
+
+```javascript
+function openSettingsFocusedOn(parsivalProject) {
+  openSettings();  // existing function that shows the modal
+  // Wait one tick for DOM to render, then scroll & focus.
+  setTimeout(() => {
+    const rows = document.querySelectorAll('#project-list [data-project-name]');
+    for (const row of rows) {
+      if (row.dataset.projectName === parsivalProject) {
+        row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        const sel = row.querySelector('.lancellmot-select');
+        if (sel) {
+          sel.focus();
+          row.style.transition = 'background 0.6s';
+          row.style.background = 'rgba(64, 184, 255, 0.12)';
+          setTimeout(() => { row.style.background = ''; }, 1400);
+        }
+        return;
+      }
+    }
+  }, 150);
+}
+```
+
+Verify that project rows have `data-project-name="${p.name}"` set — if not, add it to the row template in the rendering code (same place Task 6 modified).
+
+- [ ] **Step 2: Rebuild and visually verify**
+
+Run: `docker compose up -d --build parsival-api`
+
+Click an unmapped "Map →" chip. Expected:
+- Settings modal opens
+- Projects section is scrolled into view
+- The project row for the clicked tag flashes blue briefly
+- The lancellmot dropdown on that row is focused (keyboard-ready)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/page/index.html
+git commit -m "feat(#43): click-through from unmapped chip to Settings project row"
+```
+
+---
+
+## Task 9: Documentation
+
+**Files:**
+- Modify: `README.md`
+- Modify: `web/page/index.html` (help modal section)
+
+- [ ] **Step 1: Add lancellmot integration section to README.md**
+
+Find the existing "Configuration" or "Features" section. Append:
+
+```markdown
+### lancellmot document linking
+
+Situation cards display a chip linking to related documents in lancellmot.
+Resolution is via an explicit alias table — each parsival project is mapped
+to a lancellmot project in Settings → Projects. No fuzzy matching.
+
+- **Setup:** set `LANCELLMOT_URL` in env (default `http://host.docker.internal:8080`)
+- **Mapping:** Settings → Projects → pick lancellmot project per row
+- **Unmapped tags:** show "Map →" chip on cards; click to jump to Settings
+- **lancellmot down:** chip renders amber with "unreachable" tooltip
+```
+
+- [ ] **Step 2: Add help-modal entry**
+
+In the help modal table (search for `<table>` inside the help section), add a row:
+
+```html
+<tr><td>Map →</td><td>Project tag has no lancellmot mapping. Click to open Settings and pick the lancellmot counterpart. Mappings are explicit — parsival never guesses.</td></tr>
+<tr><td>⚠ unreachable</td><td>Couldn't reach lancellmot. Click the chip to retry, or verify lancellmot is running.</td></tr>
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md web/page/index.html
+git commit -m "docs(#43): README + help-modal entries for lancellmot chip"
+```
+
+---
+
+## Task 10: Final verification + PR
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `python3 -m pytest tests/ -v`
+Expected: all PASS
+
+- [ ] **Step 2: Visual smoke test, all states**
+
+- Resolved chip with popover and doc links
+- Unmapped chip → Settings focus
+- Unreachable chip when lancellmot is down
+- Settings dropdown updates alias round-trip
+- Multi-project situation shows multiple chips
+
+- [ ] **Step 3: Push branch and open PR**
+
+```bash
+git push
+gh pr create --repo rcanterberryhall/hexcaliper-parsival \
+  --title "feat(#43): lancellmot document chip on situation cards" \
+  --body "$(cat <<'EOF'
+## Summary
+- Strict alias table mapping parsival project tags → lancellmot projects
+- Situation cards display chip with three states (resolved / unmapped / unreachable)
+- Settings gains a dropdown column per project row for mapping
+- Click unmapped chip → Settings opens focused on that project row
+
+## Spec
+docs/superpowers/specs/2026-04-19-parsival-lancellmot-document-chip-design.md
+
+Closes #43.
+EOF
+)"
+```
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:** Every item in the spec's "Architecture" section maps to a task:
+- Data model → Task 1 ✓
+- HTTP client → Task 3 ✓
+- 5 API routes → Tasks 4 + 5 ✓
+- UI changes (card + Settings + click-through) → Tasks 6 + 7 + 8 ✓
+- Error handling (amber chip, unreachable responses) → covered across Tasks 3, 5, 7 ✓
+- Testing → covered in Tasks 1-5 ✓
+- Docs → Task 9 ✓
+
+**Placeholder scan:** No TBDs or "TODO" stubs remain. `escapeHtml` is flagged with a fallback note in Task 7 Step 2.
+
+**Type consistency:** Function names used consistently — `upsert_lancellmot_alias`, `get_lancellmot_alias_for_tag`, `list_lancellmot_aliases`, `delete_lancellmot_alias`. Route paths consistent. Chip status strings ("ok" / "unmapped" / "unreachable") match across server + client.

--- a/docs/superpowers/specs/2026-04-19-parsival-lancellmot-document-chip-design.md
+++ b/docs/superpowers/specs/2026-04-19-parsival-lancellmot-document-chip-design.md
@@ -1,0 +1,130 @@
+# Parsival → lancellmot Document Chip (parsival#43)
+
+**Date:** 2026-04-19
+**Issue:** [parsival#43](https://github.com/rcanterberryhall/hexcaliper-parsival/issues/43)
+**Scope:** Ship a visible cross-system link from parsival situations to lancellmot documents, all in one PR. Future work (parsival#50 and similar) adopts the alias primitive when it's built.
+
+---
+
+## The story
+
+A situation card in parsival gets a small chip next to the project tag. Hovering it shows the top documents from the matching lancellmot project; clicking a filename opens lancellmot's doc viewer in a new tab. If the project isn't mapped yet, the chip renders dim with a pencil icon — clicking it jumps to Settings with the relevant project row focused, where the user picks the lancellmot counterpart from a dropdown. If lancellmot is unreachable, the chip renders amber with a "retry" tooltip instead of silently hiding.
+
+No fuzzy matching. Aliases are explicit and user-maintained — the friction of hand-mapping is the forcing function that keeps naming discipline visible.
+
+No caching. Chips fetch per-render. Situation-only scope keeps N small.
+
+## Design decisions (locked)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Identity resolution | Strict alias table, no fallback | Explicit, debuggable, enforces naming discipline |
+| Chip surface | Situation cards only (not items) | Situations are the workflow surface; items are too numerous |
+| Chip payload | Popover: project name + top N filenames + link out | Filenames give context; links avoid embedding lancellmot |
+| Fetch strategy | Per-render, no cache | Situations-per-page is small; freshness trivial |
+| Multi-project situations | One chip per resolved project | Preserves project boundaries; chips wrap if needed |
+| Unresolved tag | Muted "Map →" chip | Discoverable at point-of-use; one click to bootstrap |
+| Failure mode | Amber "unreachable" chip with retry tooltip | User's stated preference: fail loud, not silent |
+| Alias UI | New column on existing Settings → Projects row | Alias is an attribute of the project; dropdown prevents typos |
+
+## Architecture
+
+### Data model
+
+New table in parsival's SQLite:
+
+```sql
+CREATE TABLE lancellmot_aliases (
+    parsival_project TEXT PRIMARY KEY,  -- matches parsival project name (from config.projects)
+    lancellmot_project_id TEXT NOT NULL,
+    lancellmot_project_name TEXT NOT NULL,  -- denormalized for display/audit
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
+```
+
+- `parsival_project` is the exact name as stored in `settings.projects[].name`.
+- `lancellmot_project_id` is the UUID/id returned by lancellmot's `/workspace/projects` endpoint.
+- `lancellmot_project_name` is denormalized so audit works even if lancellmot is down.
+
+### HTTP client
+
+New module `api/lancellmot_client.py` with three functions:
+
+```python
+def list_projects() -> list[dict]:
+    """GET {LANCELLMOT_URL}/workspace/projects → [{id, name, ...}, ...]"""
+
+def list_documents(project_id: str, limit: int = 5) -> list[dict]:
+    """GET {LANCELLMOT_URL}/documents?project_id=X → [{id, filename, ...}, ...], trimmed"""
+
+class LancellmotUnavailable(Exception):
+    """Raised on network error, timeout, or non-2xx response."""
+```
+
+- Timeout: 2s per call (fast enough to not stall card renders; long enough for local network).
+- No retry inside the client — failure bubbles to the endpoint handler, which returns a shape the UI can render as the amber chip.
+- Configured via `LANCELLMOT_URL` env var (pattern matches existing `MERLLM_URL`).
+
+### Parsival-side API
+
+New routes:
+
+```
+GET  /api/lancellmot/projects
+     → proxy to lancellmot's list; used to populate Settings dropdown.
+     → on failure: 503 with {error: "unreachable"}
+
+GET  /api/lancellmot/docs-for-tag?tag=Ethylene-Cracker-3&limit=5
+     → resolve tag via aliases table; if resolved, fetch docs from lancellmot.
+     → returns: {status: "ok", project_name, project_id, docs: [...]}
+                | {status: "unmapped", tag}
+                | {status: "unreachable", tag}
+
+GET  /api/lancellmot/aliases
+     → list all aliases for Settings audit.
+
+PUT  /api/lancellmot/aliases
+     body: {parsival_project, lancellmot_project_id, lancellmot_project_name}
+     → upsert alias.
+
+DELETE /api/lancellmot/aliases/{parsival_project}
+     → remove alias.
+```
+
+### UI changes
+
+1. **Situation card render** — for each project tag on the situation, render a chip. State depends on `GET /api/lancellmot/docs-for-tag` response:
+   - `ok` → active chip with doc count; popover on hover.
+   - `unmapped` → muted chip with pencil icon; click opens Settings.
+   - `unreachable` → amber chip; tooltip with retry hint.
+
+2. **Settings → Projects section** — add a new column "lancellmot project" to each project row. Dropdown populated from `GET /api/lancellmot/projects`, with current alias selected (or blank). On change, call `PUT /api/lancellmot/aliases`.
+
+3. **Click-to-edit from card** — unmapped chip opens Settings modal, scrolls to Projects section, focuses the row whose name matches the tag.
+
+## Error handling
+
+- lancellmot unreachable on chip fetch → amber chip, no retry inside the client.
+- lancellmot unreachable on Settings open → dropdown shows empty with an inline message "couldn't reach lancellmot — close and retry."
+- Alias points to a lancellmot project that no longer exists → lancellmot returns 404 for the doc list → chip renders as unreachable (pragmatic: the user can fix it on their next Settings visit).
+
+## Testing
+
+- **api/lancellmot_client.py**: unit tests with mocked `httpx` responses (success, timeout, 5xx, 404).
+- **Aliases CRUD**: round-trip upsert/list/delete against the real SQLite test db.
+- **docs-for-tag endpoint**: integration tests covering mapped/unmapped/unreachable paths.
+- **UI**: smoke test via playwright or the existing manual checklist — verify the three chip states render.
+
+## Out of scope (for this PR)
+
+- Bi-directional linking (lancellmot → parsival).
+- Situation-level primary-project precedence rules.
+- Background alias sync / auto-discovery.
+- Item-level chips.
+- Caching.
+
+## Follow-ups
+
+- parsival#50 adopts the alias primitive when it's built.
+- First real-use iteration informs refinements: chip density, popover N value, bootstrap friction. Expected to change based on usage.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,7 @@ def clear_db():
     import db as _db
     _db.conn().execute("DELETE FROM contact_emails")
     _db.conn().execute("DELETE FROM contacts")
+    _db.conn().execute("DELETE FROM lancellmot_aliases")
     config.PROJECTS = []
     config.FOCUS_TOPICS = []
     config.NOISE_KEYWORDS = []

--- a/tests/test_lancellmot_aliases.py
+++ b/tests/test_lancellmot_aliases.py
@@ -1,0 +1,71 @@
+"""Tests for lancellmot_aliases table + CRUD helpers (parsival#43)."""
+import db
+
+
+def test_lancellmot_aliases_table_exists():
+    cols = {r[1] for r in db.conn().execute(
+        "PRAGMA table_info(lancellmot_aliases)"
+    ).fetchall()}
+    assert cols == {
+        "parsival_project",
+        "lancellmot_project_id",
+        "lancellmot_project_name",
+        "created_at",
+        "updated_at",
+    }
+
+
+def test_upsert_creates_alias():
+    db.upsert_lancellmot_alias(
+        parsival_project="Ethylene-Cracker-3",
+        lancellmot_project_id="proj-123",
+        lancellmot_project_name="ethylene-cracker-3",
+    )
+    row = db.get_lancellmot_alias_for_tag("Ethylene-Cracker-3")
+    assert row is not None
+    assert row["lancellmot_project_id"] == "proj-123"
+    assert row["lancellmot_project_name"] == "ethylene-cracker-3"
+    assert row["created_at"]
+    assert row["updated_at"]
+
+
+def test_upsert_updates_existing_alias():
+    db.upsert_lancellmot_alias(
+        parsival_project="Alpha",
+        lancellmot_project_id="old-id",
+        lancellmot_project_name="old-name",
+    )
+    original = db.get_lancellmot_alias_for_tag("Alpha")
+    db.upsert_lancellmot_alias(
+        parsival_project="Alpha",
+        lancellmot_project_id="new-id",
+        lancellmot_project_name="new-name",
+    )
+    updated = db.get_lancellmot_alias_for_tag("Alpha")
+    assert updated["lancellmot_project_id"] == "new-id"
+    assert updated["lancellmot_project_name"] == "new-name"
+    assert updated["created_at"] == original["created_at"]
+    assert updated["updated_at"] >= original["updated_at"]
+
+
+def test_get_lancellmot_alias_returns_none_for_missing():
+    assert db.get_lancellmot_alias_for_tag("Nonexistent") is None
+
+
+def test_list_lancellmot_aliases_returns_all():
+    db.upsert_lancellmot_alias("A", "idA", "nameA")
+    db.upsert_lancellmot_alias("B", "idB", "nameB")
+    rows = db.list_lancellmot_aliases()
+    names = {r["parsival_project"] for r in rows}
+    assert {"A", "B"}.issubset(names)
+
+
+def test_delete_lancellmot_alias_removes_row():
+    db.upsert_lancellmot_alias("Doomed", "id-doom", "name-doom")
+    assert db.get_lancellmot_alias_for_tag("Doomed") is not None
+    db.delete_lancellmot_alias("Doomed")
+    assert db.get_lancellmot_alias_for_tag("Doomed") is None
+
+
+def test_delete_lancellmot_alias_missing_is_noop():
+    db.delete_lancellmot_alias("Never-Existed")  # must not raise

--- a/tests/test_lancellmot_client.py
+++ b/tests/test_lancellmot_client.py
@@ -1,0 +1,77 @@
+"""Tests for lancellmot_client (parsival#43)."""
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+import lancellmot_client
+
+
+def _ok_response(payload):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.json.return_value = payload
+    resp.raise_for_status.return_value = None
+    return resp
+
+
+def test_list_projects_returns_list_of_dicts():
+    payload = [
+        {"id": "p1", "name": "alpha"},
+        {"id": "p2", "name": "beta"},
+    ]
+    with patch("lancellmot_client.requests.get",
+               return_value=_ok_response(payload)) as mock_get:
+        result = lancellmot_client.list_projects()
+    assert result == payload
+    call_url = mock_get.call_args[0][0]
+    assert "/workspace/projects" in call_url
+
+
+def test_list_projects_raises_on_network_error():
+    with patch("lancellmot_client.requests.get",
+               side_effect=__import__("requests").ConnectionError("boom")):
+        with pytest.raises(lancellmot_client.LancellmotUnavailable):
+            lancellmot_client.list_projects()
+
+
+def test_list_projects_raises_on_timeout():
+    with patch("lancellmot_client.requests.get",
+               side_effect=__import__("requests").Timeout("slow")):
+        with pytest.raises(lancellmot_client.LancellmotUnavailable):
+            lancellmot_client.list_projects()
+
+
+def test_list_projects_raises_on_5xx():
+    bad = MagicMock()
+    bad.status_code = 503
+    bad.raise_for_status.side_effect = __import__("requests").HTTPError("503")
+    with patch("lancellmot_client.requests.get", return_value=bad):
+        with pytest.raises(lancellmot_client.LancellmotUnavailable):
+            lancellmot_client.list_projects()
+
+
+def test_list_documents_returns_trimmed_list():
+    payload = [{"id": f"d{i}", "filename": f"doc{i}.pdf"} for i in range(10)]
+    with patch("lancellmot_client.requests.get",
+               return_value=_ok_response(payload)) as mock_get:
+        result = lancellmot_client.list_documents("proj-1", limit=5)
+    assert len(result) == 5
+    assert result[0]["filename"] == "doc0.pdf"
+    call_url = mock_get.call_args[0][0]
+    assert "/documents" in call_url
+    assert mock_get.call_args.kwargs["params"] == {"project_id": "proj-1"}
+
+
+def test_list_documents_default_limit_is_5():
+    payload = [{"id": f"d{i}", "filename": f"doc{i}.pdf"} for i in range(20)]
+    with patch("lancellmot_client.requests.get",
+               return_value=_ok_response(payload)):
+        result = lancellmot_client.list_documents("proj-1")
+    assert len(result) == 5
+
+
+def test_list_documents_raises_on_failure():
+    with patch("lancellmot_client.requests.get",
+               side_effect=__import__("requests").ConnectionError("boom")):
+        with pytest.raises(lancellmot_client.LancellmotUnavailable):
+            lancellmot_client.list_documents("proj-1")

--- a/tests/test_lancellmot_routes.py
+++ b/tests/test_lancellmot_routes.py
@@ -1,0 +1,124 @@
+"""Integration tests for /lancellmot/* routes (parsival#43)."""
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from app import app
+import db
+import lancellmot_client
+
+
+client = TestClient(app)
+
+
+# ── alias CRUD ───────────────────────────────────────────────────────────────
+
+def test_get_aliases_returns_list():
+    db.upsert_lancellmot_alias("Foo", "id-foo", "foo-name")
+    db.upsert_lancellmot_alias("Bar", "id-bar", "bar-name")
+    resp = client.get("/lancellmot/aliases")
+    assert resp.status_code == 200
+    body = resp.json()
+    names = {a["parsival_project"] for a in body}
+    assert {"Foo", "Bar"}.issubset(names)
+
+
+def test_put_alias_creates_new():
+    resp = client.put("/lancellmot/aliases", json={
+        "parsival_project": "NewProj",
+        "lancellmot_project_id": "id-new",
+        "lancellmot_project_name": "new-name",
+    })
+    assert resp.status_code == 200
+    row = db.get_lancellmot_alias_for_tag("NewProj")
+    assert row["lancellmot_project_id"] == "id-new"
+
+
+def test_put_alias_updates_existing():
+    db.upsert_lancellmot_alias("Upd", "old-id", "old-name")
+    resp = client.put("/lancellmot/aliases", json={
+        "parsival_project": "Upd",
+        "lancellmot_project_id": "new-id",
+        "lancellmot_project_name": "new-name",
+    })
+    assert resp.status_code == 200
+    row = db.get_lancellmot_alias_for_tag("Upd")
+    assert row["lancellmot_project_id"] == "new-id"
+
+
+def test_put_alias_missing_field_is_400():
+    resp = client.put("/lancellmot/aliases", json={"parsival_project": "X"})
+    assert resp.status_code == 400
+
+
+def test_delete_alias_removes():
+    db.upsert_lancellmot_alias("Gone", "id-g", "g-name")
+    resp = client.delete("/lancellmot/aliases/Gone")
+    assert resp.status_code == 200
+    assert db.get_lancellmot_alias_for_tag("Gone") is None
+
+
+# ── projects proxy ────────────────────────────────────────────────────────────
+
+def test_get_lancellmot_projects_proxies_client():
+    fake_projects = [{"id": "p1", "name": "alpha"}, {"id": "p2", "name": "beta"}]
+    with patch("app.lancellmot_client.list_projects", return_value=fake_projects):
+        resp = client.get("/lancellmot/projects")
+    assert resp.status_code == 200
+    assert resp.json() == fake_projects
+
+
+def test_get_lancellmot_projects_503_on_unavailable():
+    with patch("app.lancellmot_client.list_projects",
+               side_effect=lancellmot_client.LancellmotUnavailable("boom")):
+        resp = client.get("/lancellmot/projects")
+    assert resp.status_code == 503
+    assert resp.json() == {"error": "unreachable"}
+
+
+# ── docs-for-tag (render path) ────────────────────────────────────────────────
+
+def test_docs_for_tag_ok_path():
+    db.upsert_lancellmot_alias("Alpha", "proj-a", "alpha-proj")
+    fake_docs = [
+        {"id": "d1", "filename": "spec.pdf"},
+        {"id": "d2", "filename": "procedure.md"},
+    ]
+    with patch("app.lancellmot_client.list_documents",
+               return_value=fake_docs) as mock_docs:
+        resp = client.get("/lancellmot/docs-for-tag?tag=Alpha")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert body["project_name"] == "alpha-proj"
+    assert body["project_id"] == "proj-a"
+    assert body["docs"] == fake_docs
+    mock_docs.assert_called_once_with("proj-a", limit=5)
+
+
+def test_docs_for_tag_unmapped():
+    resp = client.get("/lancellmot/docs-for-tag?tag=NoAlias")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "unmapped"
+    assert body["tag"] == "NoAlias"
+
+
+def test_docs_for_tag_unreachable():
+    db.upsert_lancellmot_alias("Beta", "proj-b", "beta-proj")
+    with patch("app.lancellmot_client.list_documents",
+               side_effect=lancellmot_client.LancellmotUnavailable("down")):
+        resp = client.get("/lancellmot/docs-for-tag?tag=Beta")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "unreachable"
+    assert body["tag"] == "Beta"
+
+
+def test_docs_for_tag_respects_limit_param():
+    db.upsert_lancellmot_alias("Gamma", "proj-g", "gamma-proj")
+    with patch("app.lancellmot_client.list_documents",
+               return_value=[]) as mock_docs:
+        resp = client.get("/lancellmot/docs-for-tag?tag=Gamma&limit=3")
+    assert resp.status_code == 200
+    mock_docs.assert_called_once_with("proj-g", limit=3)

--- a/web/page/index.html
+++ b/web/page/index.html
@@ -1748,6 +1748,9 @@ tr.attn-low  { opacity:0.65; }
         <dt>Completed work in the narrative</dt><dd>When the LLM re-synthesizes a situation, done todos attached to the cluster's items are fed in as "Completed actions (treat as already done; do not re-raise)". The narrative summary reflects the current state instead of restating finished work as pending, and the open-actions list no longer surfaces items you've already closed. Use <strong>↺ Resynth</strong> to pick up newly-completed work.</dd>
         <dt>Default filter</dt><dd>The list shows <strong>new</strong>, <strong>investigating</strong>, and <strong>waiting</strong> situations by default. Toggle to see resolved/dismissed.</dd>
         <dt>Transition log</dt><dd>Every status change is logged with timestamp and optional note.</dd>
+        <dt>lancellmot chip</dt><dd>Next to a situation's project badges, a chip links to related documents in lancellmot. Resolved chips show the document count — hover for the top filenames. Mapping is explicit (Settings → Projects); lancellmot is never guessed.</dd>
+        <dt>Map →</dt><dd>The project tag has no lancellmot mapping yet. Click the chip to open Settings focused on that project row and pick the lancellmot counterpart.</dd>
+        <dt>⚠ unreachable</dt><dd>lancellmot couldn't be reached. Click the chip to retry, or verify lancellmot is running and <code>LANCELLMOT_URL</code> is correct.</dd>
       </dl>
     </div>
 

--- a/web/page/index.html
+++ b/web/page/index.html
@@ -494,7 +494,7 @@ body { background: var(--bg); color: var(--text); font-family: var(--mono); font
 .project-picker button:hover { background: var(--border); color: var(--accent); }
 .project-picker .no-projects { font-size: 10px; color: var(--muted); padding: 5px 9px; }
 .project-row {
-  display: grid; grid-template-columns: 1fr 1.5fr 1fr 1fr auto; gap: 6px; align-items: start;
+  display: grid; grid-template-columns: 1fr 1.5fr 1fr 1fr 1fr auto; gap: 6px; align-items: start;
   margin-bottom: 8px;
 }
 .project-row input, .project-row textarea, .project-row select {
@@ -506,9 +506,10 @@ body { background: var(--bg); color: var(--text); font-family: var(--mono); font
 .project-row input:focus, .project-row textarea:focus, .project-row select:focus { border-color: var(--accent); }
 .project-row select { appearance: none; cursor: pointer; }
 .project-row-head {
-  display: grid; grid-template-columns: 1fr 1.5fr 1fr 1fr auto; gap: 6px;
+  display: grid; grid-template-columns: 1fr 1.5fr 1fr 1fr 1fr auto; gap: 6px;
   margin-bottom: 4px;
 }
+.lmot-select { max-width: 100%; }
 .project-row-head span { font-size: 9px; letter-spacing: .14em; text-transform: uppercase; color: var(--muted); padding: 0 2px; }
 .learned-panel {
   grid-column: 1 / -1;
@@ -583,6 +584,29 @@ body { background: var(--bg); color: var(--text); font-family: var(--mono); font
 .situation-card.score-high     { border-color: var(--amber); border-left-width: 3px; }
 .situation-card.score-medium   { border-color: var(--accent); }
 .situation-card.score-low      { border-color: var(--border); }
+.lmot-chip-host { display: inline-flex; gap: 4px; flex-wrap: wrap; }
+.lmot-chip {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 10px; padding: 2px 7px; border-radius: 10px;
+  border: 1px solid var(--border2); background: rgba(64,184,255,0.08);
+  color: var(--blue); cursor: pointer; margin-left: 4px; position: relative;
+}
+.lmot-chip.unmapped { background: transparent; color: var(--muted); border-style: dashed; }
+.lmot-chip.unreachable { background: rgba(255,180,60,0.10); color: var(--amber); border-color: var(--amber); }
+.lmot-popover {
+  position: absolute; top: calc(100% + 4px); left: 0;
+  min-width: 220px; max-width: 320px; background: var(--surface);
+  border: 1px solid var(--border2); border-radius: 6px; padding: 8px 10px;
+  box-shadow: 0 4px 14px rgba(0,0,0,0.4); z-index: 100; font-size: 11px;
+  white-space: normal; cursor: default;
+}
+.lmot-popover .lmot-popover-head { color: var(--muted); font-weight: bold; margin-bottom: 4px; }
+.lmot-popover .lmot-doc { display: block; padding: 2px 0; color: var(--text); word-break: break-all; }
+.lmot-popover a {
+  display: block; color: var(--blue); text-decoration: none;
+  padding-top: 4px; margin-top: 4px; border-top: 1px solid var(--border2);
+}
+.lmot-popover a:hover { text-decoration: underline; }
 .sit-header { display: flex; align-items: flex-start; gap: 10px; padding: 10px 12px 8px; cursor: pointer; }
 .sit-score  { font-family: var(--display); font-size: 18px; font-weight: 700; min-width: 36px; text-align: center; line-height: 1; padding-top: 2px; flex-shrink: 0; }
 .score-critical .sit-score { color: var(--red); }
@@ -1505,7 +1529,7 @@ tr.attn-low  { opacity:0.65; }
       <div class="field">
         <label>Projects</label>
         <div class="project-row-head" id="project-list-head" style="display:none">
-          <span>Name / Parent</span><span>Description</span><span>Keywords</span><span>Senders</span><span></span>
+          <span>Name / Parent</span><span>Description</span><span>Keywords</span><span>Senders</span><span>lancellmot</span><span></span>
         </div>
         <div id="project-list"></div>
         <button class="connect-btn" style="margin-top:6px" onclick="addProjectRow()">+ Add Project</button>
@@ -3101,6 +3125,107 @@ function renderSituations(situations) {
     return;
   }
   el.innerHTML = visible.map(s => situationCard(s)).join('');
+  hydrateLancellmotChips();
+}
+
+// After situation cards render, fill each card's lancellmot chip host. Each
+// project tag fetches /lancellmot/docs-for-tag and resolves to one of three
+// chip states: resolved (doc count + hover popover), unmapped ("Map →" →
+// Settings), or unreachable (amber, click to retry). Hosts are hydrated once
+// per render via a data-flag guard (parsival#43).
+function hydrateLancellmotChips() {
+  document.querySelectorAll('.lmot-chip-host').forEach(host => {
+    if (host.dataset.hydrated) return;
+    host.dataset.hydrated = '1';
+    let tags = [];
+    try { tags = JSON.parse(host.dataset.tags || '[]'); } catch (_) {}
+    renderLancellmotChips(host, tags);
+  });
+}
+
+async function renderLancellmotChips(host, tags) {
+  host.innerHTML = '';
+  for (const tag of tags) {
+    const chip = document.createElement('span');
+    chip.className = 'lmot-chip';
+    chip.textContent = tag + ' · …';
+    host.appendChild(chip);
+    let body;
+    try {
+      body = await api('/lancellmot/docs-for-tag?tag=' + encodeURIComponent(tag));
+    } catch (_) {
+      _setChipUnreachable(chip, tag, host, tags);
+      continue;
+    }
+    if (body.status === 'ok') {
+      const n = body.docs.length;
+      chip.textContent = tag + ' · ' + n + ' doc' + (n === 1 ? '' : 's');
+      chip.title = 'Related documents in lancellmot';
+      chip.onmouseenter = () => showLancellmotPopover(chip, body);
+      chip.onmouseleave = () => hideLancellmotPopover(chip);
+      chip.onclick = (e) => e.stopPropagation();
+    } else if (body.status === 'unmapped') {
+      chip.classList.add('unmapped');
+      chip.textContent = tag + ' · Map →';
+      chip.title = 'No lancellmot mapping yet — click to map';
+      chip.onclick = (e) => { e.stopPropagation(); openSettingsFocusedOn(tag); };
+    } else {
+      _setChipUnreachable(chip, tag, host, tags);
+    }
+  }
+}
+
+function _setChipUnreachable(chip, tag, host, tags) {
+  chip.className = 'lmot-chip unreachable';
+  chip.textContent = tag + ' · ⚠ unreachable';
+  chip.title = "Couldn't reach lancellmot — click to retry";
+  chip.onclick = (e) => {
+    e.stopPropagation();
+    host.dataset.hydrated = '';
+    renderLancellmotChips(host, tags);
+  };
+}
+
+function showLancellmotPopover(chip, body) {
+  hideLancellmotPopover(chip);
+  const pop = document.createElement('div');
+  pop.className = 'lmot-popover';
+  pop.onclick = (e) => e.stopPropagation();
+  const head = document.createElement('div');
+  head.className = 'lmot-popover-head';
+  head.textContent = body.project_name;
+  pop.appendChild(head);
+  if (!body.docs.length) {
+    const empty = document.createElement('div');
+    empty.className = 'lmot-doc';
+    empty.style.color = 'var(--muted)';
+    empty.textContent = 'No documents';
+    pop.appendChild(empty);
+  } else {
+    for (const d of body.docs) {
+      const docEl = document.createElement('div');
+      docEl.className = 'lmot-doc';
+      docEl.textContent = d.filename || d.title || d.id;
+      pop.appendChild(docEl);
+    }
+  }
+  // Deep-linking into lancellmot's doc viewer is gated behind an explicit
+  // browser-facing URL; only render the link when one is configured so we
+  // never ship a chip that points at a non-existent route.
+  if (window.LANCELLMOT_WEB_URL) {
+    const link = document.createElement('a');
+    link.href = window.LANCELLMOT_WEB_URL;
+    link.target = '_blank';
+    link.rel = 'noopener';
+    link.textContent = 'Open lancellmot →';
+    pop.appendChild(link);
+  }
+  chip.appendChild(pop);
+}
+
+function hideLancellmotPopover(chip) {
+  const ex = chip.querySelector('.lmot-popover');
+  if (ex) ex.remove();
 }
 
 function situationCard(s) {
@@ -3111,6 +3236,10 @@ function situationCard(s) {
   ).join('');
   const priLabel    = `<span class="badge b-${s.priority||'low'}">${s.priority||'low'}</span>`;
   const projLabel   = projBadges(s);
+  const lmotTags    = parseTags(s.project_tag);
+  const lmotHost    = lmotTags.length
+    ? `<span class="lmot-chip-host" data-tags="${esc(JSON.stringify(lmotTags))}"></span>`
+    : '';
   const statusLabel = `<span class="sit-detail-status status-${s.status||'informational'}">${(s.status||'informational').replace('_',' ')}</span>`;
   const actions     = (s.open_actions||[]).filter(a => a.owner === 'me' || a.owner === 'Me');
   const actLine     = actions.length
@@ -3162,7 +3291,7 @@ function situationCard(s) {
           <div class="sit-summary">${esc(s.summary)}</div>
           <div class="sit-meta">
             <div class="sit-src-dots">${srcDots}</div>
-            ${priLabel}${projLabel}${statusLabel}
+            ${priLabel}${projLabel}${lmotHost}${statusLabel}
             ${lcDropdown}${followUpField}
             <span style="font-size:10px;color:var(--muted)">${s.item_count} item${s.item_count!==1?'s':''}</span>
             ${actLine}
@@ -4471,6 +4600,31 @@ function closeSettings() {
   _removeSecretFields();
 }
 
+// Open Settings and bring the matching project row into view, focused on its
+// lancellmot dropdown, so an unmapped chip is one click from being mapped.
+// Project rows load asynchronously, so we poll briefly for the row to appear.
+function openSettingsFocusedOn(parsivalProject) {
+  openSettings();
+  let tries = 0;
+  const seek = () => {
+    const rows = document.querySelectorAll('#project-list .project-row');
+    for (const row of rows) {
+      const name = (row.querySelector('.proj-name') || {}).value || '';
+      if (name === parsivalProject) {
+        row.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        const sel = row.querySelector('.lmot-select');
+        if (sel) sel.focus();
+        row.style.transition = 'background 0.6s';
+        row.style.background = 'rgba(64,184,255,0.12)';
+        setTimeout(() => { row.style.background = ''; }, 1400);
+        return;
+      }
+    }
+    if (++tries < 12) setTimeout(seek, 150);
+  };
+  setTimeout(seek, 150);
+}
+
 const SCHEDULE_SOURCES  = ['slack','github','jira','outlook','teams'];
 const SCHEDULE_OPTIONS  = [
   { label: 'Off',   value: 0   },
@@ -4980,13 +5134,18 @@ function addProjectRow(p = {}) {
     <textarea class="proj-desc" placeholder="Short description of scope, location, or purpose…">${esc(p.description || '')}</textarea>
     <input type="text" class="proj-kw" placeholder="alpha, PA-" value="${esc((p.keywords || []).join(', '))}">
     <input type="text" class="proj-senders" placeholder="jane@co.com, John Smith" value="${esc((p.senders || []).join(', '))}">
+    <select class="lmot-select" title="Map this project to a lancellmot project">
+      <option value="">— none —</option>
+    </select>
     <button class="ia del" onclick="removeProjectRow(this)" title="Remove">✕</button>
     <div class="learned-panel" style="display:none"></div>`;
 
   // Store parent value for after dropdown is populated
   row.dataset.parentVal = parentVal;
+  row.dataset.projectName = p.name || '';
   list.appendChild(row);
   _refreshParentDropdowns();
+  if (!_loadingProjects) populateLancellmotDropdowns();
 }
 
 function _refreshParentDropdowns() {
@@ -5101,10 +5260,87 @@ function readProjects() {
   }).filter(p => p.name);
 }
 
+let _loadingProjects = false;
+
 function loadProjects(projects) {
   $('project-list').innerHTML = '';
   $('project-list-head').style.display = 'none';
+  _loadingProjects = true;
   (projects || []).forEach(p => addProjectRow(p));
+  _loadingProjects = false;
+  populateLancellmotDropdowns();
+}
+
+// Populate every project row's lancellmot dropdown from /lancellmot/projects
+// and select the current alias for each. If lancellmot is unreachable the
+// dropdown disables itself with a visible "unreachable" option rather than
+// silently rendering empty (parsival#43).
+async function populateLancellmotDropdowns() {
+  let projects = null;
+  try {
+    const r = await fetch(API + '/lancellmot/projects');
+    if (!r.ok) throw new Error('unreachable');
+    projects = await r.json();
+  } catch (_) {
+    projects = null;
+  }
+  let aliases = [];
+  try { aliases = await api('/lancellmot/aliases'); } catch (_) {}
+  const aliasByTag = {};
+  for (const a of aliases) aliasByTag[a.parsival_project] = a;
+
+  document.querySelectorAll('.lmot-select').forEach(sel => {
+    const row = sel.closest('.project-row');
+    const parsivalProj = (row && (row.querySelector('.proj-name') || {}).value) || '';
+    sel.innerHTML = '';
+    const none = document.createElement('option');
+    none.value = '';
+    none.textContent = '— none —';
+    sel.appendChild(none);
+    if (projects === null) {
+      sel.disabled = true;
+      const err = document.createElement('option');
+      err.textContent = 'lancellmot unreachable';
+      err.disabled = true;
+      sel.appendChild(err);
+      return;
+    }
+    sel.disabled = false;
+    for (const p of projects) {
+      const o = document.createElement('option');
+      o.value = p.id;
+      o.textContent = p.name;
+      o.dataset.name = p.name;
+      sel.appendChild(o);
+    }
+    const current = aliasByTag[parsivalProj];
+    if (current) sel.value = current.lancellmot_project_id;
+    if (!sel.dataset.wired) {
+      sel.dataset.wired = '1';
+      sel.addEventListener('change', () => onLancellmotSelectChange(sel));
+    }
+  });
+}
+
+async function onLancellmotSelectChange(sel) {
+  const row = sel.closest('.project-row');
+  const parsivalProj = ((row && (row.querySelector('.proj-name') || {}).value) || '').trim();
+  if (!parsivalProj) return;
+  if (sel.value === '') {
+    try {
+      await fetch(API + '/lancellmot/aliases/' + encodeURIComponent(parsivalProj),
+                  { method: 'DELETE' });
+    } catch (_) {}
+    return;
+  }
+  const picked = sel.options[sel.selectedIndex];
+  try {
+    await api('/lancellmot/aliases', 'PUT', {
+      parsival_project: parsivalProj,
+      lancellmot_project_id: sel.value,
+      lancellmot_project_name: picked.dataset.name || picked.textContent,
+    });
+  } catch (_) {}
 }
 
 async function clearNoiseFilter() {


### PR DESCRIPTION
## Summary

Implements the design + plan on the `design/issue-43-document-chip` branch (both spec docs are included here so they merge alongside the code).

- **Strict alias table** (`lancellmot_aliases`) mapping each Parsival project name → a lancellmot project. No fuzzy matching — explicit, user-maintained.
- **HTTP client** (`api/lancellmot_client.py`) wrapping lancellmot's `/workspace/projects` and `/documents?project_id=` with a 2s timeout; any failure raises `LancellmotUnavailable`.
- **Five routes** under `/lancellmot/*`: alias CRUD (`GET/PUT/DELETE`), a `projects` proxy (503 `{error:"unreachable"}` when lancellmot is down), and `docs-for-tag` returning one of three shapes (`ok` / `unmapped` / `unreachable`).
- **Situation-card chip** with three states: resolved (doc count + hover popover of filenames), unmapped (dashed `Map →` → opens Settings on that row), unreachable (amber `⚠`, click to retry). Fail-loud, never silent.
- **Settings → Projects** gains a `lancellmot` dropdown column per row; selecting persists the alias immediately, "— none —" deletes it, and lancellmot-down disables the dropdown with a visible notice.
- `LANCELLMOT_URL` config + docker-compose wiring; README section + in-app help entries.

## Deviations from the plan (codebase reality)

The plan was written against an idealized `api.` package layout; these were adjusted to match the actual code:

- **Routes are bare `/lancellmot/*`, not `/api/lancellmot/*`.** Parsival's nginx already namespaces the API under `/page/api/`, and every existing route is bare — the `/api/` prefix would have produced `/page/api/api/...`.
- **Test imports are top-level** (`import db`, `from app import app`) because `conftest.py` puts `api/` on `sys.path` — not `from api import ...`.
- **DB helpers follow the in-repo idiom**: `_now_iso()` (not `datetime.utcnow()`), `sqlite3.Row` → `dict(row)`, autocommit connection (no `.commit()`), and routes hold `db.lock` (released before the network call in `docs-for-tag`).
- **No fabricated deep-links.** lancellmot's SPA has no `/document/{id}` or `/project/{id}` routes and there's no browser-facing lancellmot URL configured (`LANCELLMOT_URL` uses `host.docker.internal`). The popover lists filenames as text; an "Open lancellmot →" link only renders when an optional `window.LANCELLMOT_WEB_URL` global is set, so the chip never points at a 404. **Wiring a real browser-facing URL + lancellmot deep-link routes is the one follow-up.**

## Tests

- 25 new tests (`test_lancellmot_aliases.py`, `test_lancellmot_client.py`, `test_lancellmot_routes.py`) covering DB CRUD, the HTTP client (success/timeout/5xx/trim), and all route shapes.
- Full suite: **469 passed** (was 444). `conftest.py` now wipes `lancellmot_aliases` between tests.
- Embedded `<script>` passes `node --check`.

Closes #43.

**Visual verification pending — automated agent. Manual browser check required before merge.**